### PR TITLE
fix(llm): strip leaked reasoning traces from model output

### DIFF
--- a/core/llm.py
+++ b/core/llm.py
@@ -4,6 +4,7 @@ import base64
 import json
 import logging
 import os
+import re
 from typing import Any, AsyncIterator
 
 import httpx
@@ -531,6 +532,55 @@ def _extract_responses_result(response: Any) -> dict[str, Any]:
     return {"content": content, "tool_calls": tool_calls, "raw": response}
 
 
+_REASONING_PATTERNS = [
+    # DeepSeek/Qwen-style reasoning tags, if they surface inline in `content`.
+    re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE),
+    # Gemma 4 native reasoning channel — <|channel>thought ... <channel|>.
+    # A well-behaved Gemma 4 emits these special tokens; llama.cpp does not
+    # parse them, so they leak into `content`.
+    re.compile(r"<\|?channel\|?>\s*thought\b.*?<\|?channel\|?>", re.DOTALL | re.IGNORECASE),
+    # Markdown-fenced reasoning block — ```thought ... ``` — the form actually
+    # observed in production: an abliterated Gemma 4 merge degrades special-token
+    # adherence and approximates its thought channel as a plaintext fence.
+    re.compile(r"```(?:thought|thinking|reasoning)\b.*?```", re.DOTALL | re.IGNORECASE),
+]
+
+
+def strip_reasoning(content: str) -> str:
+    """
+    Remove leaked chain-of-thought from model output.
+
+    Some models — abliterated community merges in particular — emit their
+    reasoning trace as visible content instead of through a separate reasoning
+    channel: either ``<think>...</think>`` tags or a ```thought fenced block.
+    Hexis never wants that text in a user-facing reply.
+
+    Model-agnostic and a no-op when the content is already clean, so it is safe
+    to apply unconditionally regardless of which model/provider is configured.
+    """
+    if not content:
+        return content
+    lowered = content.lower()
+    if "```" not in content and "<think>" not in lowered and "channel" not in lowered:
+        return content
+    cleaned = content
+    for pat in _REASONING_PATTERNS:
+        cleaned = pat.sub("", cleaned)
+    cleaned = cleaned.strip()
+    if cleaned == content:
+        return content
+    if not cleaned:
+        logger.warning(
+            "strip_reasoning: model output was entirely reasoning trace, "
+            "nothing left after strip (%d chars removed)", len(content),
+        )
+        return ""
+    logger.info(
+        "strip_reasoning: removed %d chars of leaked reasoning", len(content) - len(cleaned),
+    )
+    return cleaned
+
+
 _PROVIDER_ALIASES: dict[str, str] = {
     "openai_chat_completions_endpoint": "openai-chat-completions-endpoint",
     "openai_codex": "openai-codex",
@@ -1004,7 +1054,7 @@ async def chat_completion(
         async def _do_chat_completion():
             response = await client.chat.completions.create(**payload)
             message = response.choices[0].message
-            content = message.content or ""
+            content = strip_reasoning(message.content or "")
             tool_calls = _openai_tool_calls(message.tool_calls or [])
             return {"content": content, "tool_calls": tool_calls, "raw": response}
 
@@ -1263,7 +1313,11 @@ async def stream_chat_completion(
                     logger.debug("Failed to parse tool arguments: %r", raw_args[:200])
                     args = {}
                 tool_calls.append({"id": tc["id"], "name": tc["name"], "arguments": args})
-            return {"content": "".join(content_parts), "tool_calls": tool_calls, "raw": None}
+            return {
+                "content": strip_reasoning("".join(content_parts)),
+                "tool_calls": tool_calls,
+                "raw": None,
+            }
 
         return await _retry_on_transient(_do_stream_completion)
 


### PR DESCRIPTION
## Context

Hexis already supports `provider=openai_compatible` against any OpenAI-shape endpoint. A common deployment for that is `llama.cpp` (or another local server) hosting a community open-weights fine-tune. Hosted cloud APIs (OpenAI / Anthropic / etc) sanitize reasoning channels server-side; local servers serving fine-tunes generally do not. This PR adds a small defensive cleaner for the class of output-noise that surfaces specifically in that combination.

## The leak

Some community fine-tunes leak their chain-of-thought into visible `content` instead of a separate reasoning channel. Three patterns observed in practice:

- `<think>...</think>` tags (DeepSeek/Qwen-style if they surface inline in `content`)
- `<|channel>thought ... <channel|>` (Gemma 4 native special tokens that llama.cpp does not parse out)
- ```` ```thought ... ``` ```` markdown fence (the form actually observed on some fine-tunes whose special-token adherence degrades; the thought channel ends up as a plaintext fence)

Without a backstop, that text — including any recited internal scaffolding like persona prompt or memory context — reaches the user. The `enable_thinking=false` chat-template kwarg helps on some templates (Qwen3, Gemma 4) but is unreliable across community derivatives.

## The fix

Adds `strip_reasoning()` in `core/llm.py` as the load-bearing backstop:

- Model-agnostic — pattern-based on the three forms above
- Applied at both OpenAI-compatible content-extraction sites (`chat_completion` and `stream_chat_completion` return paths), so chat / RLM / heartbeat are all covered
- No-op when content is already clean (early-return guard checks for `` ``` ``, `<think>`, `channel` substrings before running the regex pass)
- Logs INFO with chars removed on strip; WARNING when content was entirely reasoning trace

Cloud-API users see no behavior change (the early-return guard fires immediately on clean content).

## Files

`core/llm.py` — new `strip_reasoning()` function + 2 callsite hookups. +56 / -2.

## Test plan

- Existing tests in `tests/core/test_llm.py` and `tests/core/test_chat.py` still pass
- Manual: chat with a Gemma 4 community fine-tune via `provider=openai_compatible` against a local `llama.cpp` serving the model — confirm reply text no longer contains a ```` ```thought ```` fence
- No-op confirmation: chat with `gpt-4o` (or any model that does not leak reasoning) — verify output is unchanged byte-for-byte

## Future work (NOT in this PR)

A sibling helper `strip_leading_divider()` for a different output-noise pattern (lone `---` horizontal rule at the start of a reply, observed on the same family of fine-tunes). Same general bug shape; kept separate to keep this PR focused on the reasoning-trace fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LLM response quality by removing leaked internal reasoning and chain-of-thought text from model outputs. The system now automatically filters various reasoning formats to deliver cleaner, professional responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuixiAI/Hexis/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->