### PR TITLE
Make custom inference setup explicit and safe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Copy this file to .env and edit only the settings you need.
+# The .env file is ignored by Git. Never commit real credentials.
+
+# PostgreSQL
+POSTGRES_DB=hexis_memory
+POSTGRES_USER=hexis_user
+POSTGRES_PASSWORD=hexis_password
+POSTGRES_HOST=localhost
+POSTGRES_PORT=43815
+
+# Bind local services to this machine only. Use 0.0.0.0 only when you
+# intentionally want other machines to reach them.
+HEXIS_BIND_ADDRESS=127.0.0.1
+
+# OpenAI Platform or a custom OpenAI-compatible endpoint.
+# Uncomment these lines and replace the values when using either provider.
+# OPENAI_API_KEY=replace-with-your-key
+# OPENAI_BASE_URL=http://localhost:8000/v1
+
+# Other API-key providers. Uncomment only the one you use.
+# ANTHROPIC_API_KEY=replace-with-your-key
+# GEMINI_API_KEY=replace-with-your-key
+# XAI_API_KEY=replace-with-your-key
+
+# A server that does not authenticate still needs a non-secret value because
+# the OpenAI client requires one, for example: OPENAI_API_KEY=not-needed

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ ENV/
 .env
 .env.*
 !.env.local
+!.env.example
 
 # PostgreSQL
 *.sql.gz

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Quick version:
 
 ```bash
 git clone https://github.com/QuixiAI/Hexis.git && cd Hexis
-pip install -e . && cp .env.local .env
+pip install -e . && cp .env.example .env
 hexis up && hexis doctor
 pytest tests -q
 ```

--- a/README.md
+++ b/README.md
@@ -142,8 +142,10 @@ hexis init --character jarvis --provider github-copilot --model gpt-4o
 # Chutes (free inference)
 hexis init --character hexis --provider chutes --model deepseek-ai/DeepSeek-V3-0324
 
-# Local OpenAI-compatible endpoint
-hexis init --provider openai_compatible --model local-model --character hexis
+# Custom OpenAI-compatible endpoint
+# First set OPENAI_BASE_URL and OPENAI_API_KEY in .env (see .env.example).
+hexis init --provider openai_compatible --model your-model-id --character hexis \
+  --api-key-env OPENAI_API_KEY
 
 # API-key providers (auto-detect from prefix)
 hexis init --character jarvis --api-key sk-...
@@ -240,7 +242,7 @@ See [Quickstart](docs/start/quickstart.md) for setup and [Production](docs/opera
 git clone https://github.com/QuixiAI/Hexis.git && cd Hexis
 uv venv && source .venv/bin/activate
 uv pip install -e .
-cp .env.local .env
+cp .env.example .env   # edit with your settings; never commit .env
 hexis up
 ```
 

--- a/apps/hexis_init.py
+++ b/apps/hexis_init.py
@@ -2,8 +2,8 @@
 
 Flow: [LLM Config] → [Choose Path] → [Express | Character | Custom] → [Consent] → [Done]
 
-Non-interactive mode: pass --api-key (and optionally --character, --provider, --model)
-to skip the wizard and configure everything from CLI flags.
+Non-interactive mode: pass provider/model flags with either --api-key or
+--api-key-env to skip the wizard and configure everything from CLI flags.
 """
 from __future__ import annotations
 
@@ -40,6 +40,7 @@ from apps.cli_theme import console, err_console, heading, make_panel, make_table
 _PROVIDER_ENV_VARS: dict[str, str] = {
     "anthropic": "ANTHROPIC_API_KEY",
     "openai": "OPENAI_API_KEY",
+    "openai_compatible": "OPENAI_API_KEY",
     "openai-codex": "",
     "grok": "XAI_API_KEY",
     "gemini": "GEMINI_API_KEY",
@@ -84,6 +85,77 @@ def _normalize_provider_name(provider: str | None) -> str:
         "google_antigravity": "google-antigravity",
     }
     return _ALIASES.get(raw, raw)
+
+
+def _resolve_noninteractive_provider(args: argparse.Namespace) -> str:
+    """Resolve a provider only from values the user explicitly selected."""
+    provider = _normalize_provider_name(args.provider)
+    if provider:
+        return provider
+    if args.endpoint:
+        return "openai_compatible"
+    if args.api_key:
+        return detect_provider(args.api_key)
+    if args.api_key_env:
+        api_key = os.getenv(args.api_key_env)
+        if not api_key:
+            raise ValueError(
+                f"Environment variable {args.api_key_env} is not set. "
+                "Add it to .env, then re-run init."
+            )
+        return detect_provider(api_key)
+    return "openai-codex"
+
+
+def _resolve_noninteractive_endpoint(
+    args: argparse.Namespace,
+    provider: str,
+) -> tuple[str, str]:
+    """Return the endpoint and its visible source label."""
+    endpoint = (args.endpoint or "").strip()
+    source = "--endpoint" if endpoint else ""
+    if not endpoint and provider == "openai_compatible":
+        endpoint = os.getenv("OPENAI_BASE_URL", "").strip()
+        source = "OPENAI_BASE_URL" if endpoint else ""
+    if provider == "openai_compatible" and not endpoint:
+        raise ValueError(
+            "An OpenAI-compatible endpoint is required. Pass --endpoint URL "
+            "or set OPENAI_BASE_URL in .env."
+        )
+    return endpoint, source
+
+
+def _resolve_noninteractive_api_key_env(
+    args: argparse.Namespace,
+    provider: str,
+) -> str:
+    """Choose a credential env var without silently consuming ambient keys."""
+    if provider in _OAUTH_PROVIDERS:
+        return ""
+
+    api_key_env = (args.api_key_env or _PROVIDER_ENV_VARS.get(provider, "")).strip()
+    if args.api_key:
+        if not api_key_env:
+            raise ValueError(
+                f"No default API key variable is known for provider '{provider}'. "
+                "Use --api-key-env NAME instead."
+            )
+        return api_key_env
+
+    if not args.api_key_env:
+        suggestion = (
+            f" --api-key-env {api_key_env}" if api_key_env else " --api-key-env NAME"
+        )
+        raise ValueError(
+            f"API key configuration is required for provider '{provider}'. "
+            f"Set the key in .env and pass{suggestion}, or pass --api-key."
+        )
+    if not os.getenv(api_key_env):
+        raise ValueError(
+            f"Environment variable {api_key_env} is not set. "
+            "Add it to .env, then re-run init."
+        )
+    return api_key_env
 
 
 async def _ensure_oauth_login(
@@ -338,13 +410,7 @@ def _ensure_embedding_model() -> None:
 async def _run_init_noninteractive(args: argparse.Namespace) -> int:
     """Non-interactive init: configure from CLI flags, start stack, apply config."""
     # 1. Detect provider
-    provider = _normalize_provider_name(args.provider)
-    if not provider:
-        if args.api_key:
-            provider = detect_provider(args.api_key)
-        else:
-            provider = "openai-codex"
-    provider = _normalize_provider_name(provider)
+    provider = _resolve_noninteractive_provider(args)
     persist_provider = provider
 
     # The Anthropic browser-OAuth (Claude Pro/Max) login was removed — the
@@ -354,10 +420,6 @@ async def _run_init_noninteractive(args: argparse.Namespace) -> int:
             "[fail]Anthropic OAuth login is no longer supported. Use "
             "`hexis auth anthropic setup-token` then `--provider anthropic`, "
             "or pass an Anthropic API key.[/fail]")
-        return 1
-
-    if provider not in _OAUTH_PROVIDERS and not args.api_key:
-        err_console.print(f"[fail]--api-key required for provider '{provider}'[/fail]")
         return 1
 
     # 2. Resolve model — derive from the live catalog (not a stale hard-code).
@@ -372,13 +434,23 @@ async def _run_init_noninteractive(args: argparse.Namespace) -> int:
         if not model:
             err_console.print(f"[fail]Could not determine a default model for '{provider}'. Pass --model.[/fail]")
             return 1
-    api_key_env = "" if provider in _no_key_needed else _PROVIDER_ENV_VARS.get(provider, "")
+    endpoint, endpoint_source = _resolve_noninteractive_endpoint(args, provider)
+    api_key_env = _resolve_noninteractive_api_key_env(args, provider)
 
-    console.print(make_panel(
-        f"[key]Provider:[/key] {persist_provider}\n"
-        f"[key]Model:[/key]    {model}",
-        title="Non-Interactive Init",
-    ))
+    config_summary = (
+        f"[key]Provider:[/key]  {persist_provider}\n"
+        f"[key]Model:[/key]     {model}"
+    )
+    if endpoint:
+        config_summary += (
+            f"\n[key]Endpoint:[/key]  {endpoint} "
+            f"[muted]({endpoint_source})[/muted]"
+        )
+    if api_key_env:
+        config_summary += (
+            f"\n[key]API key:[/key]   {api_key_env} environment variable"
+        )
+    console.print(make_panel(config_summary, title="Non-Interactive Init"))
 
     # 3. Write API key to .env + set os.environ
     if args.api_key and api_key_env:
@@ -415,7 +487,7 @@ async def _run_init_noninteractive(args: argparse.Namespace) -> int:
         heartbeat_config = {
             "provider": persist_provider,
             "model": model,
-            "endpoint": "",
+            "endpoint": endpoint,
             "api_key_env": api_key_env,
         }
         subconscious_config = heartbeat_config.copy()
@@ -1261,13 +1333,29 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--dsn", default=None, help="Postgres DSN; defaults to POSTGRES_* env vars")
     p.add_argument("--wait-seconds", type=int, default=int(os.getenv("POSTGRES_WAIT_SECONDS", "30")))
 
-    # Non-interactive mode flags (any of --api-key, --provider, --character triggers it)
-    p.add_argument("--api-key", default=None,
-                    help="API key (auto-detects provider; triggers non-interactive mode)")
+    # Supplying any of these flags selects non-interactive mode in main().
+    credential_source = p.add_mutually_exclusive_group()
+    credential_source.add_argument(
+        "--api-key",
+        default=None,
+        help="API key (auto-detects provider; writes the key to .env)",
+    )
+    credential_source.add_argument(
+        "--api-key-env",
+        default=None,
+        metavar="NAME",
+        help="Read the API key from this environment variable (keeps secrets out of shell history)",
+    )
     p.add_argument("--provider", default=None,
                     help="LLM provider (auto-detected from --api-key if omitted)")
     p.add_argument("--model", default=None,
                     help="LLM model (defaults per provider)")
+    p.add_argument(
+        "--endpoint",
+        default=None,
+        metavar="URL",
+        help="LLM base URL (defaults to OPENAI_BASE_URL for openai_compatible)",
+    )
     p.add_argument("--character", default=None,
                     help="Character card name (e.g. 'hexis', 'jarvis'). Omit for express defaults")
     p.add_argument("--name", default=None,
@@ -1284,7 +1372,7 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
 
     # Non-interactive mode if any of these flags are present
-    if args.api_key or args.provider or args.character:
+    if args.api_key or args.api_key_env or args.endpoint or args.provider or args.character:
         try:
             return asyncio.run(_run_init_noninteractive(args))
         except KeyboardInterrupt:

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -15,7 +15,7 @@ section: contributing
 git clone https://github.com/QuixiAI/Hexis.git && cd Hexis
 uv venv && source .venv/bin/activate
 uv pip install -e .
-cp .env.local .env   # edit with your API keys
+cp .env.example .env   # edit with your settings; never commit .env
 hexis up             # start services
 hexis doctor         # verify health
 ```

--- a/docs/integrations/auth/index.md
+++ b/docs/integrations/auth/index.md
@@ -28,6 +28,25 @@ All providers can be used for any LLM slot (`llm.chat`, `llm.heartbeat`, `llm.su
 
 API-key providers (`openai`, `anthropic`, `grok`, `gemini`) can also use traditional environment variables (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) instead of OAuth.
 
+For a custom OpenAI-compatible endpoint, put the endpoint and key in the
+project's ignored `.env` file:
+
+```dotenv
+OPENAI_BASE_URL=https://your-inference-server.example/v1
+OPENAI_API_KEY=replace-with-your-key
+```
+
+Then configure Hexis without exposing the key in shell history:
+
+```bash
+hexis init --provider openai_compatible --model your-model-id --character hexis \
+  --api-key-env OPENAI_API_KEY
+```
+
+The endpoint and environment variable name are stored in the brain; the key
+itself remains in `.env`. Use `OPENAI_API_KEY=not-needed` for an unauthenticated
+server because the OpenAI client still requires a value.
+
 ---
 
 ## OpenAI Codex (ChatGPT Subscription)

--- a/docs/operations/environment-variables.md
+++ b/docs/operations/environment-variables.md
@@ -35,13 +35,15 @@ All environment variables used by Hexis, configured via `.env`.
 | `EMBEDDING_MODEL_ID` | `embeddinggemma:300m-qat-q4_0` | Model identifier |
 | `EMBEDDING_DIMENSION` | `768` | Vector dimension |
 
-## LLM API Keys
+## LLM Providers
 
 | Variable | Description |
 |----------|-------------|
-| `OPENAI_API_KEY` | OpenAI Platform API key |
+| `OPENAI_API_KEY` | OpenAI Platform or OpenAI-compatible API key |
+| `OPENAI_BASE_URL` | Base URL for `openai_compatible`; used as the `hexis init` endpoint default only when that provider is selected |
 | `ANTHROPIC_API_KEY` | Anthropic API key |
-| `GROK_API_KEY` | Grok API key |
+| `GEMINI_API_KEY` | Google Gemini API key |
+| `XAI_API_KEY` | xAI Grok API key |
 
 These are only needed for API-key providers. OAuth providers store credentials in the database.
 

--- a/docs/start/installation.md
+++ b/docs/start/installation.md
@@ -100,7 +100,7 @@ For development or contributing:
 git clone https://github.com/QuixiAI/Hexis.git && cd Hexis
 uv venv && source .venv/bin/activate
 uv pip install -e .
-cp .env.local .env   # edit with your settings
+cp .env.example .env   # edit with your settings; never commit .env
 ```
 
 No uv? A plain virtualenv works too: `python3 -m venv .venv && source .venv/bin/activate && pip install -e .`
@@ -113,25 +113,34 @@ pip install -e . --no-build-isolation
 
 ## Environment Configuration
 
-Create a `.env` file (automatically created by `hexis init` for packaged installs):
+Copy the tracked template, then edit only the settings you need. The resulting
+`.env` is ignored by Git:
 
 ```bash
-POSTGRES_DB=hexis_memory
-POSTGRES_USER=hexis_user
-POSTGRES_PASSWORD=hexis_password
-POSTGRES_HOST=localhost
-POSTGRES_PORT=43815
-HEXIS_BIND_ADDRESS=127.0.0.1    # Set to 0.0.0.0 to expose services
+cp .env.example .env
 ```
 
 If port `43815` is already in use, set `POSTGRES_PORT` to any free port.
 
-For LLM API keys (if using API-key providers):
+For a custom OpenAI-compatible server, set its base URL and key in `.env`:
+
+```dotenv
+OPENAI_BASE_URL=https://your-inference-server.example/v1
+OPENAI_API_KEY=replace-with-your-key
+```
+
+Then initialize with the model ID exposed by that server. `--api-key-env` tells
+Hexis which variable to read without putting the secret in shell history:
 
 ```bash
-OPENAI_API_KEY=sk-...           # OpenAI Platform
-ANTHROPIC_API_KEY=sk-ant-...    # Anthropic
+hexis init --provider openai_compatible --model your-model-id --character hexis \
+  --api-key-env OPENAI_API_KEY
 ```
+
+If the server does not authenticate, use a non-secret placeholder such as
+`OPENAI_API_KEY=not-needed`; the OpenAI client still requires a value. Hexis
+stores the endpoint and the environment variable's **name** in PostgreSQL, not
+the key itself.
 
 See [Environment Variables](../operations/environment-variables.md) for the complete reference.
 

--- a/docs/start/quickstart.md
+++ b/docs/start/quickstart.md
@@ -60,14 +60,18 @@ hexis init --character jarvis --api-key sk-...
 # Anthropic
 hexis init --provider anthropic --model claude-sonnet-4-20250514 --api-key sk-ant-...
 
-# Local OpenAI-compatible endpoint
-hexis init --provider openai_compatible --model local-model --character hexis
+# Custom OpenAI-compatible endpoint
+# Set OPENAI_BASE_URL and OPENAI_API_KEY in .env first (see .env.example).
+hexis init --provider openai_compatible --model your-model-id --character hexis \
+  --api-key-env OPENAI_API_KEY
 
 # Express defaults (no character card)
 hexis init --api-key sk-ant-...
 ```
 
-`hexis init` auto-detects the provider from API key prefixes. For all supported providers, see [Auth Providers](../integrations/auth/index.md).
+`hexis init` auto-detects the provider from API key prefixes. `--api-key-env`
+reads a named variable from `.env`, keeping the key out of shell history. For
+all supported providers, see [Auth Providers](../integrations/auth/index.md).
 
 ## Verify It Worked
 

--- a/tests/cli/test_init_noninteractive.py
+++ b/tests/cli/test_init_noninteractive.py
@@ -8,6 +8,9 @@ import pytest
 
 from apps.hexis_init import (
     _PROVIDER_ENV_VARS,
+    _resolve_noninteractive_api_key_env,
+    _resolve_noninteractive_endpoint,
+    _resolve_noninteractive_provider,
     _write_env_var,
     build_parser,
     detect_provider,
@@ -91,6 +94,7 @@ def test_build_parser_noninteractive_flags():
         "--character", "hexis",
         "--provider", "anthropic",
         "--model", "claude-sonnet-4-20250514",
+        "--endpoint", "https://llm.example/v1",
         "--name", "Alice",
         "--no-docker",
         "--no-pull",
@@ -99,6 +103,7 @@ def test_build_parser_noninteractive_flags():
     assert args.character == "hexis"
     assert args.provider == "anthropic"
     assert args.model == "claude-sonnet-4-20250514"
+    assert args.endpoint == "https://llm.example/v1"
     assert args.name == "Alice"
     assert args.no_docker is True
     assert args.no_pull is True
@@ -108,9 +113,11 @@ def test_build_parser_defaults():
     parser = build_parser()
     args = parser.parse_args([])
     assert args.api_key is None
+    assert args.api_key_env is None
     assert args.character is None
     assert args.provider is None
     assert args.model is None
+    assert args.endpoint is None
     assert args.name is None
     assert args.no_docker is False
     assert args.no_pull is False
@@ -126,12 +133,102 @@ def test_default_models_derive_from_live_catalog():
     models.dev catalog via model_catalog.recommended_default (Bar #1)."""
     from apps.tui import model_catalog
 
-    # Every provider maps to a models.dev slug.
-    for provider in _PROVIDER_ENV_VARS:
+    # Catalog-backed providers map to models.dev. A custom endpoint cannot:
+    # its model list is defined by that server, so callers pass --model.
+    for provider in set(_PROVIDER_ENV_VARS) - {"openai_compatible"}:
         assert provider in model_catalog.PROVIDER_SLUG, f"No catalog slug for {provider}"
     # The flagship heuristic picks a sensible non-variant default.
     assert model_catalog.recommended_default(
         "openai", ["gpt-5.5-pro", "gpt-5.5", "gpt-5.4-mini"]) == "gpt-5.5"
+
+
+# ---------------------------------------------------------------------------
+# Safe custom-endpoint configuration
+# ---------------------------------------------------------------------------
+
+
+def test_openai_compatible_resolves_explicit_endpoint_and_key_env(monkeypatch):
+    monkeypatch.setenv("INFERENCE_API_KEY", "test-key")
+    args = build_parser().parse_args([
+        "--provider", "openai_compatible",
+        "--model", "served-model",
+        "--endpoint", "https://llm.example/v1",
+        "--api-key-env", "INFERENCE_API_KEY",
+    ])
+
+    provider = _resolve_noninteractive_provider(args)
+    endpoint, source = _resolve_noninteractive_endpoint(args, provider)
+
+    assert provider == "openai_compatible"
+    assert endpoint == "https://llm.example/v1"
+    assert source == "--endpoint"
+    assert _resolve_noninteractive_api_key_env(args, provider) == "INFERENCE_API_KEY"
+
+
+def test_openai_compatible_uses_documented_env_endpoint(monkeypatch):
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://llm.example/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    args = build_parser().parse_args([
+        "--provider", "openai_compatible",
+        "--model", "served-model",
+        "--api-key-env", "OPENAI_API_KEY",
+    ])
+
+    endpoint, source = _resolve_noninteractive_endpoint(args, "openai_compatible")
+
+    assert endpoint == "https://llm.example/v1"
+    assert source == "OPENAI_BASE_URL"
+    assert _resolve_noninteractive_api_key_env(args, "openai_compatible") == "OPENAI_API_KEY"
+
+
+def test_openai_compatible_requires_endpoint(monkeypatch):
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    args = build_parser().parse_args([
+        "--provider", "openai_compatible",
+        "--model", "served-model",
+        "--api-key-env", "OPENAI_API_KEY",
+    ])
+
+    with pytest.raises(ValueError, match="--endpoint URL or set OPENAI_BASE_URL"):
+        _resolve_noninteractive_endpoint(args, "openai_compatible")
+
+
+def test_api_key_env_must_be_set(monkeypatch):
+    monkeypatch.delenv("MISSING_API_KEY", raising=False)
+    args = build_parser().parse_args([
+        "--provider", "openai_compatible",
+        "--model", "served-model",
+        "--endpoint", "https://llm.example/v1",
+        "--api-key-env", "MISSING_API_KEY",
+    ])
+
+    with pytest.raises(ValueError, match="MISSING_API_KEY is not set"):
+        _resolve_noninteractive_api_key_env(args, "openai_compatible")
+
+
+def test_ambient_key_requires_explicit_selection(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "ambient-key")
+    args = build_parser().parse_args([
+        "--provider", "openai",
+        "--model", "served-model",
+    ])
+
+    with pytest.raises(ValueError, match="--api-key-env OPENAI_API_KEY"):
+        _resolve_noninteractive_api_key_env(args, "openai")
+
+
+def test_standard_openai_does_not_inherit_custom_endpoint(monkeypatch):
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://unrelated.example/v1")
+    args = build_parser().parse_args([
+        "--provider", "openai",
+        "--model", "served-model",
+        "--api-key", "sk-test-key",
+    ])
+
+    endpoint, source = _resolve_noninteractive_endpoint(args, "openai")
+
+    assert endpoint == ""
+    assert source == ""
 
 
 # ---------------------------------------------------------------------------
@@ -151,6 +248,8 @@ async def test_cli_init_help():
     )
     assert p.returncode == 0
     assert "--api-key" in p.stdout
+    assert "--api-key-env" in p.stdout
+    assert "--endpoint" in p.stdout
     assert "--character" in p.stdout
     assert "--provider" in p.stdout
     assert "--no-docker" in p.stdout


### PR DESCRIPTION
## Why

The source setup had no conventional environment example, and the documented OpenAI-compatible init command could not supply an endpoint or safely select a key stored in the environment. Non-interactive init also failed before it could configure that provider.

## What changed

- add a tracked .env.example with safe placeholders and local defaults
- document the exact custom endpoint and authentication flow across the README and setup references
- add --endpoint and --api-key-env to non-interactive init
- persist the selected endpoint and API-key environment variable name, never the key itself
- fail early with actionable guidance when the endpoint or selected key variable is missing
- prevent standard OpenAI setup from inheriting a stale custom endpoint

## Validation

- 26 focused init and LLM-config tests passed
- compiled apps/hexis_init.py successfully
- exercised the documented flow with dummy credentials through the database handoff
- verified missing credentials fail before Docker or database access
- git diff --check passed

## Database impact

No schema changes and no database reset required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring custom OpenAI-compatible endpoints and selecting the environment variable containing the API key during initialization.
  * Added a comprehensive environment configuration template covering database, service binding, provider, and authentication settings.
  * Improved support for OAuth-based providers and unauthenticated server configurations.

* **Documentation**
  * Updated installation, quickstart, operations, integration, and contribution guides with the new configuration workflow.
  * Clarified that credentials remain in environment files while endpoint settings are saved during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->