### PR TITLE
Add daily journal fallback for days with real activity

### DIFF
--- a/db/00_tables.sql
+++ b/db/00_tables.sql
@@ -874,6 +874,11 @@ INSERT INTO config_defaults (key, value, description) VALUES
     ('maintenance.working_memory_promote_min_accesses', '3'::jsonb, 'Working-memory items accessed >= this count are promoted on expiry')
 ON CONFLICT (key) DO NOTHING;
 INSERT INTO config_defaults (key, value, description) VALUES
+    ('maintenance.daily_journal_fallback_enabled', 'true'::jsonb, 'If a local day had meaningful activity and nothing was journaled deliberately, write one minimal fallback entry (issue #114)'),
+    ('maintenance.daily_journal_fallback_hour', '21'::jsonb, 'Local hour (agent.timezone) after which the daily journal fallback may consider stepping in'),
+    ('maintenance.daily_journal_fallback_min_episodes', '3'::jsonb, 'Minimum notable (importance >= 0.5) episodic memories in the local day for the fallback to consider it "meaningful activity"')
+ON CONFLICT (key) DO NOTHING;
+INSERT INTO config_defaults (key, value, description) VALUES
     ('memory.recall_min_trust_level', '0'::jsonb, 'Minimum trust_level to include in recall (0 disables filtering)'),
     ('memory.recall_strength_weight', '0.5'::jsonb, 'How much computed memory strength (recency/reinforcement/decay) reshapes the pure-cosine recall score: 0=pure similarity, 0.5=gentle, 1=score fully scaled by strength'),
     ('memory.recall_low_vividness_threshold', '0.35'::jsonb, 'Recall below this strength/fidelity vividness renders as a hedged reconstruction ("I vaguely recall...")'),

--- a/db/07_functions_heartbeat.sql
+++ b/db/07_functions_heartbeat.sql
@@ -1082,6 +1082,7 @@ DECLARE
     activation_decay INT;
     activation_cleaned INT;
     ready_transformations JSONB;
+    journal_fallback JSONB;
 BEGIN
     IF is_agent_terminated() THEN
         RETURN jsonb_build_object('skipped', true, 'reason', 'terminated');
@@ -1131,6 +1132,14 @@ BEGIN
         RAISE WARNING 'memory retention pass failed: %', SQLERRM;
     END;
 
+    -- Daily journal fallback (issue #114). (Kept in sync with the db/28
+    -- dopamine override, which is the live version.)
+    BEGIN
+        journal_fallback := maybe_write_daily_journal_fallback();
+    EXCEPTION WHEN OTHERS THEN
+        RAISE WARNING 'daily journal fallback failed: %', SQLERRM;
+    END;
+
     UPDATE maintenance_state
     SET last_maintenance_at = CURRENT_TIMESTAMP,
         updated_at = CURRENT_TIMESTAMP
@@ -1147,6 +1156,7 @@ BEGIN
         'activation_boosts_decayed', COALESCE(activation_decay, 0),
         'memory_activations_cleaned', COALESCE(activation_cleaned, 0),
         'transformations_ready', COALESCE(ready_transformations, '[]'::jsonb),
+        'daily_journal_fallback', COALESCE(journal_fallback, jsonb_build_object('skipped', true, 'reason', 'error')),
         'ran_at', CURRENT_TIMESTAMP
     );
 EXCEPTION

--- a/db/28_functions_dopamine.sql
+++ b/db/28_functions_dopamine.sql
@@ -615,6 +615,7 @@ DECLARE
     activation_cleaned INT;
     ready_transformations JSONB;
     dopamine_drift JSONB;
+    journal_fallback JSONB;
 BEGIN
     IF is_agent_terminated() THEN
         RETURN jsonb_build_object('skipped', true, 'reason', 'terminated');
@@ -665,6 +666,15 @@ BEGIN
         RAISE WARNING 'memory retention pass failed: %', SQLERRM;
     END;
 
+    -- Daily journal fallback (issue #114): a day with real activity and no
+    -- deliberate entry gets one minimal one. Guarded so a failure never breaks
+    -- the maintenance tick.
+    BEGIN
+        journal_fallback := maybe_write_daily_journal_fallback();
+    EXCEPTION WHEN OTHERS THEN
+        RAISE WARNING 'daily journal fallback failed: %', SQLERRM;
+    END;
+
     UPDATE maintenance_state
     SET last_maintenance_at = CURRENT_TIMESTAMP,
         updated_at = CURRENT_TIMESTAMP
@@ -682,6 +692,7 @@ BEGIN
         'memory_activations_cleaned', COALESCE(activation_cleaned, 0),
         'transformations_ready', COALESCE(ready_transformations, '[]'::jsonb),
         'dopamine_drift', COALESCE(dopamine_drift, '{}'::jsonb),
+        'daily_journal_fallback', COALESCE(journal_fallback, jsonb_build_object('skipped', true, 'reason', 'error')),
         'ran_at', CURRENT_TIMESTAMP
     );
 EXCEPTION

--- a/db/46_functions_journal.sql
+++ b/db/46_functions_journal.sql
@@ -164,3 +164,112 @@ BEGIN
     RETURN tool_error('Unsupported journal tool: ' || COALESCE(p_tool_name, '<null>'), 'invalid_params');
 END;
 $$;
+
+-- The journal is deliberate by design (see header) -- but "deliberate" has meant
+-- "never" in practice: write_journal has fired zero times live even on days the
+-- agent had plenty to say (issue #114). This is the one exception: called from
+-- subconscious maintenance, it steps in ONLY once, late in the local day, and
+-- ONLY when there was meaningful activity (real episodic memories) and nothing
+-- was journaled deliberately. It never fires twice for the same local date and
+-- never substitutes for a deliberate entry that already exists.
+CREATE OR REPLACE FUNCTION maybe_write_daily_journal_fallback()
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_tz TEXT := COALESCE(
+        NULLIF(get_config_text('agent.timezone'), ''),
+        NULLIF(get_config_text('heartbeat.timezone'), ''),
+        'UTC'
+    );
+    v_local_ts TIMESTAMP;
+    v_local_date DATE;
+    v_local_hour INT;
+    v_state JSONB;
+    v_already_journaled BOOLEAN;
+    v_min_count INT;
+    v_count INT;
+    v_samples TEXT[];
+    v_content TEXT;
+    v_entry_id UUID;
+BEGIN
+    IF NOT COALESCE(get_config_bool('maintenance.daily_journal_fallback_enabled'), true) THEN
+        RETURN jsonb_build_object('skipped', true, 'reason', 'disabled');
+    END IF;
+
+    BEGIN
+        v_local_ts := CURRENT_TIMESTAMP AT TIME ZONE v_tz;
+    EXCEPTION WHEN OTHERS THEN
+        v_local_ts := CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
+    END;
+    v_local_date := v_local_ts::date;
+    v_local_hour := EXTRACT(HOUR FROM v_local_ts)::int;
+
+    -- Give the agent the whole local day to journal deliberately before this
+    -- fallback ever considers stepping in.
+    IF v_local_hour < COALESCE(get_config_int('maintenance.daily_journal_fallback_hour'), 21) THEN
+        RETURN jsonb_build_object('skipped', true, 'reason', 'too_early', 'local_hour', v_local_hour);
+    END IF;
+
+    v_state := COALESCE(get_state('daily_journal_fallback'), '{}'::jsonb);
+    IF v_state->>'last_checked_date' = v_local_date::text THEN
+        RETURN jsonb_build_object('skipped', true, 'reason', 'already_checked_today');
+    END IF;
+
+    -- Record the attempt regardless of outcome -- a quiet day, or one already
+    -- journaled, should not be re-evaluated every maintenance tick until midnight.
+    PERFORM set_state('daily_journal_fallback', jsonb_build_object('last_checked_date', v_local_date::text));
+
+    SELECT EXISTS (
+        SELECT 1 FROM journal_entries
+        WHERE (written_at AT TIME ZONE v_tz)::date = v_local_date
+    ) INTO v_already_journaled;
+    IF v_already_journaled THEN
+        RETURN jsonb_build_object('skipped', true, 'reason', 'already_journaled', 'date', v_local_date);
+    END IF;
+
+    v_min_count := GREATEST(COALESCE(get_config_int('maintenance.daily_journal_fallback_min_episodes'), 3), 1);
+    SELECT count(*)::int INTO v_count
+    FROM memories
+    WHERE type = 'episodic'
+      AND status = 'active'
+      AND importance >= 0.5
+      AND (created_at AT TIME ZONE v_tz)::date = v_local_date;
+
+    IF v_count < v_min_count THEN
+        RETURN jsonb_build_object('skipped', true, 'reason', 'not_enough_activity',
+                                   'episodes', v_count, 'threshold', v_min_count);
+    END IF;
+
+    SELECT array_agg(top.snippet) INTO v_samples
+    FROM (
+        SELECT left(content, 140) AS snippet
+        FROM memories
+        WHERE type = 'episodic'
+          AND status = 'active'
+          AND importance >= 0.5
+          AND (created_at AT TIME ZONE v_tz)::date = v_local_date
+        ORDER BY importance DESC, created_at DESC
+        LIMIT 5
+    ) top;
+
+    v_content := 'A day worth remembering, though I never stopped to write it myself: '
+        || array_to_string(v_samples, ' ~ ');
+
+    v_entry_id := write_journal_entry(
+        p_content  := v_content,
+        p_title    := 'Auto-noted -- ' || to_char(v_local_date, 'FMMonth DD, YYYY'),
+        p_tags     := ARRAY['auto-generated'],
+        p_metadata := jsonb_build_object(
+            'source', 'subconscious_daily_fallback',
+            'episode_count', v_count,
+            'date', v_local_date::text
+        )
+    );
+
+    RETURN jsonb_build_object(
+        'journaled', true, 'entry_id', v_entry_id,
+        'episode_count', v_count, 'date', v_local_date
+    );
+END;
+$$;

--- a/db/migrations/0239_daily_journal_fallback.sql
+++ b/db/migrations/0239_daily_journal_fallback.sql
@@ -1,0 +1,223 @@
+-- Daily journal fallback (issue #114): journal_entries had zero rows ever,
+-- despite the prompt nagging the agent to journal and every write/read/search
+-- path working end to end. Journaling stayed 100% opt-in and the agent simply
+-- never opted in. This adds one narrow, DB-owned exception: subconscious
+-- maintenance may write a single minimal entry for a local day that had real
+-- activity (meaningful episodic memories) and nothing journaled deliberately.
+-- It fires at most once per local date, never overwrites/duplicates a
+-- deliberate entry, and is fully guarded so a failure never breaks maintenance.
+SET search_path = public, ag_catalog, "$user";
+SET check_function_bodies = off;
+
+INSERT INTO config_defaults (key, value, description) VALUES
+    ('maintenance.daily_journal_fallback_enabled', 'true'::jsonb, 'If a local day had meaningful activity and nothing was journaled deliberately, write one minimal fallback entry (issue #114)'),
+    ('maintenance.daily_journal_fallback_hour', '21'::jsonb, 'Local hour (agent.timezone) after which the daily journal fallback may consider stepping in'),
+    ('maintenance.daily_journal_fallback_min_episodes', '3'::jsonb, 'Minimum notable (importance >= 0.5) episodic memories in the local day for the fallback to consider it "meaningful activity"')
+ON CONFLICT (key) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION maybe_write_daily_journal_fallback()
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_tz TEXT := COALESCE(
+        NULLIF(get_config_text('agent.timezone'), ''),
+        NULLIF(get_config_text('heartbeat.timezone'), ''),
+        'UTC'
+    );
+    v_local_ts TIMESTAMP;
+    v_local_date DATE;
+    v_local_hour INT;
+    v_state JSONB;
+    v_already_journaled BOOLEAN;
+    v_min_count INT;
+    v_count INT;
+    v_samples TEXT[];
+    v_content TEXT;
+    v_entry_id UUID;
+BEGIN
+    IF NOT COALESCE(get_config_bool('maintenance.daily_journal_fallback_enabled'), true) THEN
+        RETURN jsonb_build_object('skipped', true, 'reason', 'disabled');
+    END IF;
+
+    BEGIN
+        v_local_ts := CURRENT_TIMESTAMP AT TIME ZONE v_tz;
+    EXCEPTION WHEN OTHERS THEN
+        v_local_ts := CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
+    END;
+    v_local_date := v_local_ts::date;
+    v_local_hour := EXTRACT(HOUR FROM v_local_ts)::int;
+
+    -- Give the agent the whole local day to journal deliberately before this
+    -- fallback ever considers stepping in.
+    IF v_local_hour < COALESCE(get_config_int('maintenance.daily_journal_fallback_hour'), 21) THEN
+        RETURN jsonb_build_object('skipped', true, 'reason', 'too_early', 'local_hour', v_local_hour);
+    END IF;
+
+    v_state := COALESCE(get_state('daily_journal_fallback'), '{}'::jsonb);
+    IF v_state->>'last_checked_date' = v_local_date::text THEN
+        RETURN jsonb_build_object('skipped', true, 'reason', 'already_checked_today');
+    END IF;
+
+    -- Record the attempt regardless of outcome -- a quiet day, or one already
+    -- journaled, should not be re-evaluated every maintenance tick until midnight.
+    PERFORM set_state('daily_journal_fallback', jsonb_build_object('last_checked_date', v_local_date::text));
+
+    SELECT EXISTS (
+        SELECT 1 FROM journal_entries
+        WHERE (written_at AT TIME ZONE v_tz)::date = v_local_date
+    ) INTO v_already_journaled;
+    IF v_already_journaled THEN
+        RETURN jsonb_build_object('skipped', true, 'reason', 'already_journaled', 'date', v_local_date);
+    END IF;
+
+    v_min_count := GREATEST(COALESCE(get_config_int('maintenance.daily_journal_fallback_min_episodes'), 3), 1);
+    SELECT count(*)::int INTO v_count
+    FROM memories
+    WHERE type = 'episodic'
+      AND status = 'active'
+      AND importance >= 0.5
+      AND (created_at AT TIME ZONE v_tz)::date = v_local_date;
+
+    IF v_count < v_min_count THEN
+        RETURN jsonb_build_object('skipped', true, 'reason', 'not_enough_activity',
+                                   'episodes', v_count, 'threshold', v_min_count);
+    END IF;
+
+    SELECT array_agg(top.snippet) INTO v_samples
+    FROM (
+        SELECT left(content, 140) AS snippet
+        FROM memories
+        WHERE type = 'episodic'
+          AND status = 'active'
+          AND importance >= 0.5
+          AND (created_at AT TIME ZONE v_tz)::date = v_local_date
+        ORDER BY importance DESC, created_at DESC
+        LIMIT 5
+    ) top;
+
+    v_content := 'A day worth remembering, though I never stopped to write it myself: '
+        || array_to_string(v_samples, ' ~ ');
+
+    v_entry_id := write_journal_entry(
+        p_content  := v_content,
+        p_title    := 'Auto-noted -- ' || to_char(v_local_date, 'FMMonth DD, YYYY'),
+        p_tags     := ARRAY['auto-generated'],
+        p_metadata := jsonb_build_object(
+            'source', 'subconscious_daily_fallback',
+            'episode_count', v_count,
+            'date', v_local_date::text
+        )
+    );
+
+    RETURN jsonb_build_object(
+        'journaled', true, 'entry_id', v_entry_id,
+        'episode_count', v_count, 'date', v_local_date
+    );
+END;
+$$;
+
+-- Re-publish run_subconscious_maintenance (db/28's version, which is the live
+-- one) with the fallback wired in, guarded so a failure never breaks the tick.
+CREATE OR REPLACE FUNCTION run_subconscious_maintenance(p_params JSONB DEFAULT '{}'::jsonb)
+RETURNS JSONB AS $$
+DECLARE
+    got_lock BOOLEAN;
+    min_imp FLOAT;
+    min_acc INT;
+    neighborhood_batch INT;
+    cache_days INT;
+    wm_stats JSONB;
+    recomputed INT;
+    cache_deleted INT;
+    bg_processed INT;
+    activation_decay INT;
+    activation_cleaned INT;
+    ready_transformations JSONB;
+    dopamine_drift JSONB;
+    journal_fallback JSONB;
+BEGIN
+    IF is_agent_terminated() THEN
+        RETURN jsonb_build_object('skipped', true, 'reason', 'terminated');
+    END IF;
+    got_lock := pg_try_advisory_lock(hashtext('hexis_subconscious_maintenance'));
+    IF NOT got_lock THEN
+        RETURN jsonb_build_object('skipped', true, 'reason', 'locked');
+    END IF;
+    min_imp := COALESCE(
+        NULLIF(p_params->>'working_memory_promote_min_importance', '')::float,
+        get_config_float('maintenance.working_memory_promote_min_importance'),
+        0.75
+    );
+    min_acc := COALESCE(
+        NULLIF(p_params->>'working_memory_promote_min_accesses', '')::int,
+        get_config_int('maintenance.working_memory_promote_min_accesses'),
+        3
+    );
+    neighborhood_batch := COALESCE(
+        NULLIF(p_params->>'neighborhood_batch_size', '')::int,
+        get_config_int('maintenance.neighborhood_batch_size'),
+        10
+    );
+    cache_days := COALESCE(
+        NULLIF(p_params->>'embedding_cache_older_than_days', '')::int,
+        get_config_int('maintenance.embedding_cache_older_than_days'),
+        7
+    );
+
+    wm_stats := cleanup_working_memory(min_imp, min_acc);
+    recomputed := batch_recompute_neighborhoods(neighborhood_batch);
+    cache_deleted := cleanup_embedding_cache((cache_days || ' days')::interval);
+    bg_processed := process_background_searches();
+    activation_decay := decay_activation_boosts();  -- dopamine-modulated
+    activation_cleaned := cleanup_memory_activations();
+    PERFORM update_mood();                           -- dopamine-modulated
+    ready_transformations := check_transformation_readiness();
+    dopamine_drift := drift_dopamine_tonic();        -- homeostatic drift
+
+    -- Memory retention (compression-native fade ladder): consolidate aged episodes
+    -- into gists, then prune past-grace originals. No-op unless retention.enabled.
+    -- Guarded so a failure never breaks the maintenance tick.
+    BEGIN
+        PERFORM run_memory_rest();
+        PERFORM run_retention_gc();
+        PERFORM request_stale_document_fades();  -- ask the user before fading their documents
+    EXCEPTION WHEN OTHERS THEN
+        RAISE WARNING 'memory retention pass failed: %', SQLERRM;
+    END;
+
+    -- Daily journal fallback (issue #114): a day with real activity and no
+    -- deliberate entry gets one minimal one. Guarded so a failure never breaks
+    -- the maintenance tick.
+    BEGIN
+        journal_fallback := maybe_write_daily_journal_fallback();
+    EXCEPTION WHEN OTHERS THEN
+        RAISE WARNING 'daily journal fallback failed: %', SQLERRM;
+    END;
+
+    UPDATE maintenance_state
+    SET last_maintenance_at = CURRENT_TIMESTAMP,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE id = 1;
+
+    PERFORM pg_advisory_unlock(hashtext('hexis_subconscious_maintenance'));
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'working_memory', wm_stats,
+        'neighborhoods_recomputed', COALESCE(recomputed, 0),
+        'embedding_cache_deleted', COALESCE(cache_deleted, 0),
+        'background_searches_processed', COALESCE(bg_processed, 0),
+        'activation_boosts_decayed', COALESCE(activation_decay, 0),
+        'memory_activations_cleaned', COALESCE(activation_cleaned, 0),
+        'transformations_ready', COALESCE(ready_transformations, '[]'::jsonb),
+        'dopamine_drift', COALESCE(dopamine_drift, '{}'::jsonb),
+        'daily_journal_fallback', COALESCE(journal_fallback, jsonb_build_object('skipped', true, 'reason', 'error')),
+        'ran_at', CURRENT_TIMESTAMP
+    );
+EXCEPTION
+    WHEN OTHERS THEN
+        PERFORM pg_advisory_unlock(hashtext('hexis_subconscious_maintenance'));
+        RAISE;
+END;
+$$ LANGUAGE plpgsql;

--- a/tests/db/test_daily_journal_fallback.py
+++ b/tests/db/test_daily_journal_fallback.py
@@ -1,0 +1,153 @@
+"""Tests for maybe_write_daily_journal_fallback() (db/46, migration 0239).
+
+Issue #114: journal_entries had zero rows ever despite a fully working write
+path, because journaling stayed 100% deliberate/opt-in. This is the one
+DB-owned exception: subconscious maintenance may write a single minimal entry
+for a local day with real activity and nothing journaled deliberately.
+
+Every test resets the shared `daily_journal_fallback` state key and pins
+agent.timezone to UTC inside its own rolled-back transaction, so real
+(possibly live) data in this database can't make the assertions flaky.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.utils import get_test_identifier
+
+pytestmark = [pytest.mark.asyncio(loop_scope="session")]
+
+
+def _j(v):
+    return json.loads(v) if isinstance(v, str) else v
+
+
+async def _reset_for_test(conn, *, hour: int, min_episodes: int = 1):
+    """Pin timezone/config and clear the once-per-day gate, all transaction-local."""
+    await conn.execute("SELECT set_state('daily_journal_fallback', '{}'::jsonb)")
+    await conn.execute(
+        "INSERT INTO config (key, value) VALUES ('agent.timezone', to_jsonb('UTC'::text)) "
+        "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+    )
+    await conn.execute(
+        "INSERT INTO config (key, value) VALUES ('maintenance.daily_journal_fallback_hour', $1::text::jsonb) "
+        "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+        str(hour),
+    )
+    await conn.execute(
+        "INSERT INTO config (key, value) VALUES "
+        "('maintenance.daily_journal_fallback_min_episodes', $1::text::jsonb) "
+        "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+        str(min_episodes),
+    )
+    await conn.execute(
+        "INSERT INTO config (key, value) VALUES "
+        "('maintenance.daily_journal_fallback_enabled', 'true'::jsonb) "
+        "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+    )
+    # A clean slate for "today" -- transaction-scoped, rolled back at test end.
+    await conn.execute("DELETE FROM journal_entries WHERE written_at::date = CURRENT_DATE")
+
+
+async def _seed_episodic(conn, content: str, importance: float = 0.7):
+    await conn.fetchval(
+        """
+        INSERT INTO memories (type, content, embedding, importance, trust_level, status)
+        VALUES ('episodic', $1, array_fill(0.1, ARRAY[embedding_dimension()])::vector, $2, 0.9, 'active')
+        RETURNING id
+        """,
+        content,
+        importance,
+    )
+
+
+async def test_disabled_is_skipped(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            await _reset_for_test(conn, hour=0, min_episodes=1)
+            await conn.execute(
+                "UPDATE config SET value = 'false'::jsonb "
+                "WHERE key = 'maintenance.daily_journal_fallback_enabled'"
+            )
+            result = _j(await conn.fetchval("SELECT maybe_write_daily_journal_fallback()"))
+            assert result == {"skipped": True, "reason": "disabled"}
+        finally:
+            await tr.rollback()
+
+
+async def test_too_early_in_local_day_is_skipped(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            # Threshold of 24 can never be reached by an hour-of-day (0-23).
+            await _reset_for_test(conn, hour=24, min_episodes=1)
+            result = _j(await conn.fetchval("SELECT maybe_write_daily_journal_fallback()"))
+            assert result["skipped"] is True
+            assert result["reason"] == "too_early"
+        finally:
+            await tr.rollback()
+
+
+async def test_not_enough_activity_is_skipped(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            # No real day has a million notable episodes -- deterministic regardless of live data.
+            await _reset_for_test(conn, hour=0, min_episodes=1_000_000)
+            result = _j(await conn.fetchval("SELECT maybe_write_daily_journal_fallback()"))
+            assert result["skipped"] is True
+            assert result["reason"] == "not_enough_activity"
+            assert result["threshold"] == 1_000_000
+        finally:
+            await tr.rollback()
+
+
+async def test_already_journaled_today_is_skipped(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            await _reset_for_test(conn, hour=0, min_episodes=1)
+            await conn.fetchval(
+                "SELECT write_journal_entry($1, $2)",
+                "I chose to write about it myself today.",
+                get_test_identifier("deliberate_entry"),
+            )
+            result = _j(await conn.fetchval("SELECT maybe_write_daily_journal_fallback()"))
+            assert result["skipped"] is True
+            assert result["reason"] == "already_journaled"
+        finally:
+            await tr.rollback()
+
+
+async def test_meaningful_activity_and_no_entry_writes_one_fallback_entry(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            await _reset_for_test(conn, hour=0, min_episodes=1)
+            await _seed_episodic(conn, get_test_identifier("a_notable_moment"), importance=0.8)
+
+            result = _j(await conn.fetchval("SELECT maybe_write_daily_journal_fallback()"))
+            assert result["journaled"] is True
+            entry_id = result["entry_id"]
+            assert entry_id is not None
+
+            row = await conn.fetchrow(
+                "SELECT title, tags, metadata FROM journal_entries WHERE id = $1", entry_id
+            )
+            assert row is not None
+            assert "auto-generated" in (row["tags"] or [])
+            assert _j(row["metadata"])["source"] == "subconscious_daily_fallback"
+
+            # Never fires twice for the same local date, even with activity to spare.
+            second = _j(await conn.fetchval("SELECT maybe_write_daily_journal_fallback()"))
+            assert second == {"skipped": True, "reason": "already_checked_today"}
+        finally:
+            await tr.rollback()


### PR DESCRIPTION
Fixes #114.

## What

`journal_entries` had zero rows ever, despite a fully working write/read/search
path and a prompt that actively nags the agent to journal. Journaling stayed
100% deliberate/opt-in, and in practice the agent never opted in.

This adds one narrow, DB-owned exception: subconscious maintenance may write a
single **minimal fallback entry** for a local day that had real activity and
nothing journaled deliberately.

`maybe_write_daily_journal_fallback()` (db/46) fires at most once per local
date (`agent.timezone`), and only when *all* of the following hold:

- it's past a configurable local hour (default 21:00) — gives the agent the
  whole day to journal itself first
- at least N (default 3) notable episodic memories (importance >= 0.5) were
  created that day — "meaningful activity"
- no deliberate entry already exists for that date

The fallback entry is tagged `auto-generated` with
`metadata.source = 'subconscious_daily_fallback'`, so it's always
distinguishable from something the agent chose to write. The once-per-day gate
is tracked via the existing generic `state` table (no new column/table).

Wired into `run_subconscious_maintenance()` in both db/07 (baseline) and
db/28 (the live dopamine override — kept in sync per the file's existing
comment convention), inside a guarded `BEGIN/EXCEPTION` block identical in
shape to the existing retention pass: a failure here can never break a
maintenance tick.

Three new config keys let it be tuned or disabled outright:
`maintenance.daily_journal_fallback_enabled` / `_hour` / `_min_episodes`.

`db/migrations/0239_daily_journal_fallback.sql` mirrors all of the above for
existing databases (additive, idempotent).

## Why this fix, not the other two suggested in the issue

The issue suggested three possible directions: rebalance the `write_journal`
energy cost, make the journal nudge an explicit cheap action, or wire a
subconscious fallback. The fallback is the only one of the three that
structurally guarantees the "zero entries ever" failure mode can't repeat,
without depending on tuning an incentive against an LLM's unobserved
behavior. It's also strictly additive — it doesn't touch the deliberate
tools, so tuning them later is still open.

## Testing

```
hexis migrate      # applied cleanly against the running stack
pytest tests/db/test_daily_journal_fallback.py -q      # 5 new tests, all pass
pytest tests/db/test_journal.py tests/core/test_journal_tools.py -q
pytest tests/db/test_subconscious_maintenance.py -q    # still passes
```

`tests/db/test_daily_journal_fallback.py` covers: disabled, too-early,
not-enough-activity, already-journaled-today, and the full fire-once path
(writes exactly one entry, never a second for the same date). Each test pins
`agent.timezone` and resets the once-per-day state inside its own
rolled-back transaction, so it can't be made flaky by real data already in
the database.

Two pre-existing `test_journal.py` failures (`test_write_read_search_roundtrip`,
`test_journal_absent_from_passive_recall`) are unrelated to this change — they
need the local embedding sidecar, which isn't running in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional daily journal fallback that automatically creates a journal entry when meaningful activity occurred but no deliberate entry was made.
  * Fallback entries are generated once per local day and include an auto-generated label.
  * Added settings for enabling the fallback, choosing its activation hour, and setting the minimum activity threshold.

* **Reliability**
  * Journal fallback failures no longer interrupt routine maintenance processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->