### PR TITLE
Add `hexis transcript` CLI command

### DIFF
--- a/apps/hexis_cli.py
+++ b/apps/hexis_cli.py
@@ -410,6 +410,7 @@ _HELP_GROUPS = [
         [
             ("chat", "Chat in the terminal"),
             ("chat-sessions", "List, inspect, export, and fork chat sessions"),
+            ("transcript", "Render a conversation with tool calls, signals, and corrections"),
             ("ui", "Start the web dashboard"),
             ("open", "Open the web dashboard in your browser"),
             ("tunnel", "Serve the dashboard privately over Tailscale HTTPS"),
@@ -1068,6 +1069,28 @@ def build_parser() -> argparse.ArgumentParser:
         "--raw", action="store_true", help="Show raw status (legacy format)"
     )
     status.set_defaults(func="status")
+
+    transcript = sub.add_parser(
+        "transcript",
+        parents=[_db],
+        help="Render a conversation from the DB (turns, tool calls, corrections)",
+    )
+    transcript_selector = transcript.add_mutually_exclusive_group()
+    transcript_selector.add_argument(
+        "--last", type=int, default=None, help="Render the last N turns (default 20)"
+    )
+    transcript_selector.add_argument(
+        "--session", dest="session_id", default=None,
+        help="Render every turn for this chat session or heartbeat id",
+    )
+    transcript_format = transcript.add_mutually_exclusive_group()
+    transcript_format.add_argument(
+        "--md", action="store_true", help="Render as Markdown (default)"
+    )
+    transcript_format.add_argument(
+        "--json", action="store_true", help="Render as JSON"
+    )
+    transcript.set_defaults(func="transcript")
 
     # Source-document filing cabinet (docs) + RecMem desk (desk)
     docs = sub.add_parser(
@@ -4516,6 +4539,113 @@ def _print_alive_demo(result: dict[str, Any]) -> None:
             sys.stdout.write(f"  Evidence: {rendered}\n")
         if proof.get("next_step"):
             sys.stdout.write(f"  Next: {proof['next_step']}\n")
+
+
+def _format_transcript_event(event: dict[str, Any]) -> str | None:
+    """One `[tag] ...` line per turn_id-scoped agent_turn_events row, or None
+    to skip an event type that carries no standalone signal worth a line."""
+    kind = event.get("event_type")
+    payload = event.get("payload") or {}
+    if kind == "tool_start":
+        args = json.dumps(payload.get("arguments") or {}, default=str)
+        if len(args) > 100:
+            args = args[:97] + "..."
+        return f"- [tool] calling `{payload.get('tool_name', '?')}`({args})"
+    if kind == "tool_result":
+        ok = "ok" if payload.get("success") else "FAILED"
+        duration = payload.get("duration")
+        duration_s = f"{float(duration):.2f}s" if duration is not None else "?"
+        line = (
+            f"- [tool] `{payload.get('tool_name', '?')}` -> {ok} "
+            f"({duration_s}, energy {payload.get('energy_spent', 0)})"
+        )
+        if not payload.get("success") and payload.get("error"):
+            line += f" — {payload['error']}"
+        return line
+    if kind == "energy_exhausted":
+        return (
+            f"- [energy] exhausted (budget {payload.get('budget')}, "
+            f"spent {payload.get('spent')})"
+        )
+    if kind == "claim_flagged":
+        return f"- [claim] flagged {len(payload.get('flagged') or [])} unverified statement(s)"
+    if kind == "question":
+        return f"- [question] {str(payload.get('question') or payload.get('text') or '')[:200]}"
+    if kind == "approval_request":
+        return f"- [approval] requested for `{payload.get('tool_name', payload.get('action', '?'))}`"
+    if kind == "error":
+        return f"- [error] {str(payload.get('error') or payload.get('message') or '')[:300]}"
+    if kind == "phase_change":
+        return f"- [phase] -> {payload.get('phase', '?')}"
+    return None
+
+
+def _split_transcript_user_message(raw: str | None) -> tuple[str, str | None]:
+    """Chat turns store the FULL assembled prompt as `user_message` --
+    subconscious signals, the continuity packet, identity/memory context,
+    then the literal text a human typed after a stable '[USER MESSAGE]'
+    marker (see services/agent.py's enriched_parts / services/chat.py). Pull
+    out just what was actually said, plus the '## Subconscious Signals'
+    block if present -- that block lives nowhere else, so this is the only
+    way a transcript can show it as the issue asks. Heartbeat turns carry no
+    marker and pass through unchanged."""
+    if not raw:
+        return raw or "", None
+    marker = "[USER MESSAGE]\n"
+    idx = raw.rfind(marker)
+    prefix, clean = (raw[:idx], raw[idx + len(marker):]) if idx != -1 else ("", raw)
+    signals = None
+    sig_idx = prefix.find("## Subconscious Signals")
+    if sig_idx != -1:
+        rest = prefix[sig_idx:]
+        end = rest.find("\n## ", 1)
+        signals = (rest[:end] if end != -1 else rest).strip()
+    return clean.strip(), signals
+
+
+def _render_transcript_markdown(turns: list[dict[str, Any]]) -> str:
+    """Render `hexis transcript` turns as Markdown -- one command to share or
+    archive an interaction (#54)."""
+    if not turns:
+        return "No turns found.\n"
+    lines: list[str] = []
+    for i, turn in enumerate(turns, 1):
+        label = turn.get("session_id") or turn.get("heartbeat_id")
+        heading = f"## Turn {i} — {turn.get('mode', '?')} — {turn.get('created_at', '?')}"
+        if label:
+            heading += f" (session: {label})"
+        lines.append(heading)
+        lines.append("")
+        user_text, signals = _split_transcript_user_message(turn.get("user_message"))
+        if user_text:
+            lines.append(f"**You:** {user_text}")
+            lines.append("")
+        if signals:
+            lines.append(signals)
+            lines.append("")
+        for event in turn.get("events") or []:
+            formatted = _format_transcript_event(event)
+            if formatted:
+                lines.append(formatted)
+        if turn.get("events"):
+            lines.append("")
+        if turn.get("reply_text"):
+            lines.append(f"**Agent:** {turn['reply_text']}")
+        else:
+            lines.append(f"_(turn {turn.get('status', 'unfinished')}"
+                          f"{': ' + turn['stopped_reason'] if turn.get('stopped_reason') else ''})_")
+        meta_bits = []
+        if turn.get("iterations") is not None:
+            meta_bits.append(f"{turn['iterations']} iteration(s)")
+        if turn.get("energy_spent") is not None:
+            meta_bits.append(f"{turn['energy_spent']} energy")
+        if meta_bits:
+            lines.append("")
+            lines.append(f"_{', '.join(meta_bits)}_")
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+    return "\n".join(lines)
 
 
 def _print_maturity_scorecard(result: dict[str, Any]) -> None:
@@ -8099,6 +8229,21 @@ def _dispatch(argv: list[str] | None = None) -> int:
             sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
         else:
             _print_rich_status(payload)
+        return 0
+    if func == "transcript":
+        dsn = _get_dsn(args)
+        turns = asyncio.run(
+            cli_api.transcript_payload(
+                dsn,
+                last=args.last if not args.session_id else None,
+                session_id=args.session_id,
+                wait_seconds=args.wait_seconds,
+            )
+        )
+        if args.json:
+            sys.stdout.write(json.dumps(turns, indent=2, sort_keys=True, default=str) + "\n")
+        else:
+            sys.stdout.write(_render_transcript_markdown(turns))
         return 0
     if func == "retention":
         dsn = _get_dsn(args)

--- a/core/cli_api.py
+++ b/core/cli_api.py
@@ -1393,3 +1393,32 @@ async def status_payload_rich(
         return payload
     finally:
         await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# transcript -- render conversations from agent_turns/agent_turn_events (#54)
+# ---------------------------------------------------------------------------
+
+
+async def transcript_payload(
+    dsn: str | None = None,
+    *,
+    last: int | None = None,
+    session_id: str | None = None,
+    wait_seconds: int = 30,
+) -> list[dict[str, Any]]:
+    """Fetch the turns for `hexis transcript`. Exactly one of `last` /
+    `session_id` is meaningful; get_agent_transcript ignores `last` when a
+    session_id is given (returns every turn for that session/heartbeat)."""
+    dsn = dsn or db_dsn_from_env()
+    conn = await _connect_with_retry(dsn, wait_seconds=wait_seconds)
+    try:
+        raw = await conn.fetchval(
+            "SELECT get_agent_transcript($1::int, $2::uuid)",
+            last,
+            session_id,
+        )
+        payload = json.loads(raw) if isinstance(raw, str) else raw
+        return payload or []
+    finally:
+        await conn.close()

--- a/db/32_tables_runtime.sql
+++ b/db/32_tables_runtime.sql
@@ -273,6 +273,11 @@ CREATE TABLE IF NOT EXISTS agent_turns (
 
 CREATE INDEX IF NOT EXISTS idx_agent_turns_status_created
     ON agent_turns (status, created_at DESC);
+-- `hexis transcript --session <id>` (#54) looks up by either grouping.
+CREATE INDEX IF NOT EXISTS idx_agent_turns_session
+    ON agent_turns (session_id, created_at) WHERE session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_agent_turns_heartbeat
+    ON agent_turns (heartbeat_id, created_at) WHERE heartbeat_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS agent_turn_events (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/db/37_functions_agent_runtime.sql
+++ b/db/37_functions_agent_runtime.sql
@@ -371,3 +371,63 @@ LANGUAGE sql
 AS $$
     SELECT apply_external_call_result(p_call, p_result);
 $$;
+
+-- Renders conversations for `hexis transcript` (#54): everything is already in
+-- Postgres (agent_turns for the exchange, agent_turn_events for the tool/
+-- subconscious signal trace -- keyed by turn_id, a tighter join than the
+-- loosely-typed tool_executions audit table); this just assembles it. Exactly
+-- one of p_last / p_session_id is meaningful at a time: p_session_id (a
+-- chat_sessions.id OR a heartbeat_id) returns every turn for that session in
+-- order; otherwise the most recent p_last turns across all sessions/modes.
+CREATE OR REPLACE FUNCTION get_agent_transcript(
+    p_last INT DEFAULT 20,
+    p_session_id UUID DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE sql STABLE
+AS $$
+    WITH selected_turns AS (
+        SELECT *
+        FROM agent_turns
+        WHERE p_session_id IS NULL
+           OR session_id = p_session_id
+           OR heartbeat_id = p_session_id
+        ORDER BY created_at DESC
+        LIMIT CASE WHEN p_session_id IS NULL THEN GREATEST(COALESCE(p_last, 20), 1) END
+    )
+    SELECT COALESCE(jsonb_agg(
+        jsonb_build_object(
+            'id', t.id,
+            'mode', t.mode,
+            'session_id', t.session_id,
+            'heartbeat_id', t.heartbeat_id,
+            'status', t.status,
+            'stopped_reason', t.stopped_reason,
+            'user_message', t.user_message,
+            'reply_text', COALESCE(t.result->>'visible_text', t.result->>'text'),
+            'iterations', COALESCE((t.result->>'iterations')::int, (t.runtime_state->>'iterations')::int),
+            'energy_spent', COALESCE((t.result->>'energy_spent')::numeric, (t.runtime_state->>'energy_spent')::numeric),
+            'created_at', t.created_at,
+            'completed_at', t.completed_at,
+            'events', COALESCE(ev.events, '[]'::jsonb)
+        ) ORDER BY t.created_at
+    ), '[]'::jsonb)
+    FROM selected_turns t
+    LEFT JOIN LATERAL (
+        SELECT jsonb_agg(
+            jsonb_build_object(
+                'event_type', e.event_type,
+                'payload', e.payload,
+                'created_at', e.created_at
+            ) ORDER BY e.created_at
+        ) AS events
+        FROM agent_turn_events e
+        WHERE e.turn_id = t.id
+          -- The signals worth a transcript line; llm_request/response and raw
+          -- text_delta streaming chunks would just be noise here.
+          AND e.event_type IN (
+              'tool_start', 'tool_result', 'energy_exhausted',
+              'claim_flagged', 'question', 'approval_request',
+              'error', 'phase_change'
+          )
+    ) ev ON true;
+$$;

--- a/db/migrations/0240_agent_transcript.sql
+++ b/db/migrations/0240_agent_transcript.sql
@@ -1,0 +1,74 @@
+-- `hexis transcript` (#54): a CLI command to render a conversation -- turns,
+-- tool calls, subconscious signals, energy, and any [Correction] events --
+-- from the DB, without copy-pasting out of the UI. Everything it needs is
+-- already in Postgres (agent_turns for the exchange, agent_turn_events for
+-- the per-turn signal trace); this just adds one read-only assembly function
+-- plus lookup indices for --session.
+SET search_path = public, ag_catalog, "$user";
+SET check_function_bodies = off;
+
+-- `hexis transcript --session <id>` looks up by either grouping.
+CREATE INDEX IF NOT EXISTS idx_agent_turns_session
+    ON agent_turns (session_id, created_at) WHERE session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_agent_turns_heartbeat
+    ON agent_turns (heartbeat_id, created_at) WHERE heartbeat_id IS NOT NULL;
+
+-- Renders conversations for `hexis transcript`: everything is already in
+-- Postgres (agent_turns for the exchange, agent_turn_events for the tool/
+-- subconscious signal trace -- keyed by turn_id, a tighter join than the
+-- loosely-typed tool_executions audit table); this just assembles it. Exactly
+-- one of p_last / p_session_id is meaningful at a time: p_session_id (a
+-- chat_sessions.id OR a heartbeat_id) returns every turn for that session in
+-- order; otherwise the most recent p_last turns across all sessions/modes.
+CREATE OR REPLACE FUNCTION get_agent_transcript(
+    p_last INT DEFAULT 20,
+    p_session_id UUID DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE sql STABLE
+AS $$
+    WITH selected_turns AS (
+        SELECT *
+        FROM agent_turns
+        WHERE p_session_id IS NULL
+           OR session_id = p_session_id
+           OR heartbeat_id = p_session_id
+        ORDER BY created_at DESC
+        LIMIT CASE WHEN p_session_id IS NULL THEN GREATEST(COALESCE(p_last, 20), 1) END
+    )
+    SELECT COALESCE(jsonb_agg(
+        jsonb_build_object(
+            'id', t.id,
+            'mode', t.mode,
+            'session_id', t.session_id,
+            'heartbeat_id', t.heartbeat_id,
+            'status', t.status,
+            'stopped_reason', t.stopped_reason,
+            'user_message', t.user_message,
+            'reply_text', COALESCE(t.result->>'visible_text', t.result->>'text'),
+            'iterations', COALESCE((t.result->>'iterations')::int, (t.runtime_state->>'iterations')::int),
+            'energy_spent', COALESCE((t.result->>'energy_spent')::numeric, (t.runtime_state->>'energy_spent')::numeric),
+            'created_at', t.created_at,
+            'completed_at', t.completed_at,
+            'events', COALESCE(ev.events, '[]'::jsonb)
+        ) ORDER BY t.created_at
+    ), '[]'::jsonb)
+    FROM selected_turns t
+    LEFT JOIN LATERAL (
+        SELECT jsonb_agg(
+            jsonb_build_object(
+                'event_type', e.event_type,
+                'payload', e.payload,
+                'created_at', e.created_at
+            ) ORDER BY e.created_at
+        ) AS events
+        FROM agent_turn_events e
+        WHERE e.turn_id = t.id
+          -- The signals worth a transcript line; llm_request/response and raw
+          -- text_delta streaming chunks would just be noise here.
+          AND e.event_type IN (
+              'tool_start', 'tool_result', 'energy_exhausted',
+              'claim_flagged', 'question', 'approval_request',
+              'error', 'phase_change'
+          )
+    ) ev ON true;
+$$;

--- a/tests/cli/test_transcript_cli.py
+++ b/tests/cli/test_transcript_cli.py
@@ -1,0 +1,117 @@
+"""`hexis transcript` (#54): render a conversation -- turns, tool calls,
+subconscious signals, energy, and corrections -- from the DB, end to end."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+from tests.utils import get_test_identifier
+
+pytestmark = [pytest.mark.asyncio(loop_scope="session"), pytest.mark.cli]
+
+_ROOT = str(Path(__file__).resolve().parents[2])
+
+
+def _run(*argv: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "apps.hexis_cli", *argv],
+        capture_output=True,
+        text=True,
+        env=os.environ.copy(),
+        cwd=_ROOT,
+    )
+
+
+def _j(value):
+    return json.loads(value) if isinstance(value, str) else value
+
+
+async def _seed_turn(db_pool, marker: str, session_id: str) -> str:
+    async with db_pool.acquire() as conn:
+        # A realistic chat user_message: internal context ahead of the stable
+        # '[USER MESSAGE]' marker (see services/agent.py), then the literal text.
+        user_message = (
+            "## Subconscious Signals\n"
+            f"- Instinct: curiosity (0.7) — test signal {marker}\n"
+            "\n"
+            f"[USER MESSAGE]\nwhat is {marker}?"
+        )
+        started = _j(
+            await conn.fetchval(
+                "SELECT start_agent_turn('chat', $1::text, $2::uuid, $3::jsonb)",
+                user_message, session_id, json.dumps({"messages": []}),
+            )
+        )
+        turn_id = started["turn_id"]
+        await conn.fetchval(
+            "SELECT record_agent_turn_event($1::uuid, 'tool_start', $2::jsonb)",
+            turn_id, json.dumps({"tool_name": "recall", "arguments": {"query": marker}}),
+        )
+        await conn.fetchval(
+            "SELECT record_agent_turn_event($1::uuid, 'tool_result', $2::jsonb)",
+            turn_id, json.dumps({"tool_name": "recall", "success": True, "energy_spent": 1, "duration": 0.02}),
+        )
+        await conn.fetchval(
+            "SELECT finish_agent_turn($1::uuid, $2::jsonb)",
+            turn_id, json.dumps({
+                "text": f"{marker} is a test fixture.",
+                "visible_text": f"{marker} is a test fixture.",
+                "iterations": 1, "energy_spent": 1,
+            }),
+        )
+        return turn_id
+
+
+async def test_transcript_session_json_and_markdown(db_pool):
+    marker = get_test_identifier("clitranscript")
+    session_id = str(uuid.uuid4())
+    await _seed_turn(db_pool, marker, session_id)
+
+    p = _run("transcript", "--session", session_id, "--json")
+    assert p.returncode == 0, p.stderr
+    turns = json.loads(p.stdout)
+    assert len(turns) == 1
+    assert turns[0]["session_id"] == session_id
+    # --json is the raw DB record: the internal prefix is still present.
+    assert "[USER MESSAGE]" in turns[0]["user_message"]
+
+    p = _run("transcript", "--session", session_id)
+    assert p.returncode == 0, p.stderr
+    out = p.stdout
+    # Markdown strips the internal prefix down to what was actually typed...
+    assert f"**You:** what is {marker}?" in out
+    # ...but still surfaces the subconscious-signals block the issue asks for.
+    assert "## Subconscious Signals" in out
+    assert f"test signal {marker}" in out
+    assert f"**Agent:** {marker} is a test fixture." in out
+    assert "[tool] calling `recall`" in out
+    assert "[tool] `recall` -> ok" in out
+    assert "1 energy" in out
+
+
+async def test_transcript_last_json_smoke(db_pool):
+    marker = get_test_identifier("clitranscript_last")
+    await _seed_turn(db_pool, marker, str(uuid.uuid4()))
+
+    p = _run("transcript", "--last", "1", "--json")
+    assert p.returncode == 0, p.stderr
+    turns = json.loads(p.stdout)
+    assert len(turns) == 1
+
+
+async def test_transcript_no_matches_gives_clear_message(db_pool):
+    p = _run("transcript", "--session", str(uuid.uuid4()))
+    assert p.returncode == 0, p.stderr
+    assert "No turns found" in p.stdout
+
+
+async def test_transcript_last_and_session_are_mutually_exclusive(db_pool):
+    p = _run("transcript", "--last", "1", "--session", str(uuid.uuid4()))
+    assert p.returncode != 0
+    assert "not allowed with argument" in p.stderr

--- a/tests/db/test_agent_transcript.py
+++ b/tests/db/test_agent_transcript.py
@@ -1,0 +1,152 @@
+"""Tests for get_agent_transcript() (db/37, migration 0240) -- the DB-owned
+assembly behind `hexis transcript` (#54): render a conversation -- turns,
+tool calls, subconscious/signal events, energy, corrections -- from
+agent_turns + agent_turn_events without copy-pasting out of the UI.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+
+from tests.utils import get_test_identifier
+
+pytestmark = [pytest.mark.asyncio(loop_scope="session")]
+
+
+def _j(v):
+    return json.loads(v) if isinstance(v, str) else v
+
+
+async def _start_turn(conn, mode: str, user_message: str, *, session_id=None, heartbeat_id=None):
+    context = {"messages": []}
+    if heartbeat_id:
+        context["heartbeat_id"] = heartbeat_id
+    started = _j(
+        await conn.fetchval(
+            "SELECT start_agent_turn($1::text, $2::text, $3::uuid, $4::jsonb)",
+            mode, user_message, session_id, json.dumps(context),
+        )
+    )
+    return started["turn_id"]
+
+
+async def test_transcript_by_session_id_includes_events_and_reply(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            marker = get_test_identifier("transcript")
+            session_id = str(uuid.uuid4())
+            turn_id = await _start_turn(conn, "chat", f"hello {marker}", session_id=session_id)
+
+            await conn.fetchval(
+                "SELECT record_agent_turn_event($1::uuid, 'tool_start', $2::jsonb)",
+                turn_id, json.dumps({"tool_name": "recall", "arguments": {"query": marker}}),
+            )
+            await conn.fetchval(
+                "SELECT record_agent_turn_event($1::uuid, 'tool_result', $2::jsonb)",
+                turn_id, json.dumps({
+                    "tool_name": "recall", "success": True,
+                    "energy_spent": 1, "duration": 0.05,
+                }),
+            )
+            # Noise event types (raw model I/O) must not leak into the transcript.
+            await conn.fetchval(
+                "SELECT record_agent_turn_event($1::uuid, 'llm_request', '{}'::jsonb)",
+                turn_id,
+            )
+
+            await conn.fetchval(
+                "SELECT finish_agent_turn($1::uuid, $2::jsonb)",
+                turn_id, json.dumps({
+                    "text": f"reply to {marker}",
+                    "visible_text": f"reply to {marker}",
+                    "iterations": 1, "energy_spent": 1,
+                }),
+            )
+
+            payload = _j(
+                await conn.fetchval("SELECT get_agent_transcript(NULL, $1::uuid)", session_id)
+            )
+            assert len(payload) == 1
+            turn = payload[0]
+            assert turn["session_id"] == session_id
+            assert turn["mode"] == "chat"
+            assert turn["user_message"] == f"hello {marker}"
+            assert turn["reply_text"] == f"reply to {marker}"
+            assert turn["energy_spent"] == "1" or turn["energy_spent"] == 1
+
+            event_types = [e["event_type"] for e in turn["events"]]
+            assert event_types == ["tool_start", "tool_result"]
+            assert turn["events"][1]["payload"]["success"] is True
+        finally:
+            await tr.rollback()
+
+
+async def test_transcript_last_n_orders_ascending_across_sessions(db_pool):
+    # This DB is a live instance whose own heartbeat/maintenance workers keep
+    # running concurrently, so an unscoped "last N" query can legitimately
+    # come back with real turns interleaved with these two. Ask for a huge N
+    # (guaranteed to include both regardless of concurrent activity) and
+    # check relative order only among the turns this test itself created.
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            marker = get_test_identifier("transcript_last")
+            first = await _start_turn(conn, "chat", f"first {marker}", session_id=str(uuid.uuid4()))
+            await conn.fetchval(
+                "SELECT finish_agent_turn($1::uuid, $2::jsonb)",
+                first, json.dumps({"text": "a", "visible_text": "a"}),
+            )
+            second = await _start_turn(conn, "chat", f"second {marker}", session_id=str(uuid.uuid4()))
+            await conn.fetchval(
+                "SELECT finish_agent_turn($1::uuid, $2::jsonb)",
+                second, json.dumps({"text": "b", "visible_text": "b"}),
+            )
+
+            payload = _j(await conn.fetchval("SELECT get_agent_transcript(1000, NULL)"))
+            mine = [t["id"] for t in payload if t["id"] in (first, second)]
+            assert mine == [first, second]  # ascending (chronological) order
+        finally:
+            await tr.rollback()
+
+
+async def test_transcript_by_heartbeat_id(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            marker = get_test_identifier("transcript_hb")
+            heartbeat_id = str(uuid.uuid4())
+            turn_id = await _start_turn(conn, "heartbeat", f"go {marker}", heartbeat_id=heartbeat_id)
+            await conn.fetchval(
+                "SELECT finish_agent_turn($1::uuid, $2::jsonb)",
+                turn_id, json.dumps({"text": f"did something {marker}"}),
+            )
+
+            payload = _j(
+                await conn.fetchval("SELECT get_agent_transcript(NULL, $1::uuid)", heartbeat_id)
+            )
+            assert len(payload) == 1
+            assert payload[0]["heartbeat_id"] == heartbeat_id
+            assert payload[0]["mode"] == "heartbeat"
+        finally:
+            await tr.rollback()
+
+
+async def test_transcript_no_matches_returns_empty_array(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            payload = _j(
+                await conn.fetchval(
+                    "SELECT get_agent_transcript(NULL, $1::uuid)", str(uuid.uuid4())
+                )
+            )
+            assert payload == []
+        finally:
+            await tr.rollback()


### PR DESCRIPTION
Fixes #54.

## What

`hexis transcript` renders a conversation straight from the DB — turns, tool
calls, energy, subconscious signals, and any `[Correction]` events — instead
of copy-pasting out of the UI.

```
hexis transcript --last 10           # most recent 10 turns, Markdown
hexis transcript --session <id>      # every turn for a chat session or heartbeat, Markdown
hexis transcript --last 10 --json    # raw DB records
```

`get_agent_transcript(p_last, p_session_id)` (db/37) assembles turns from
`agent_turns` with their events from `agent_turn_events` via a `turn_id`
join — tighter than the loosely-typed `tool_executions.session_id` text
field the issue originally pointed at. `p_session_id` matches either a
`chat_sessions.id` or a `heartbeat_id`. Two new partial indices back the
`--session` lookup.

## The one real wrinkle

A chat turn's stored `user_message` isn't the literal text someone typed —
it's the *entire assembled prompt* (subconscious signals, the continuity
packet, identity/memory context, then the actual message after a stable
`"[USER MESSAGE]"` marker; see `services/agent.py`'s `enriched_parts` /
`services/chat.py`). I found this by running the command against this
environment's own live data before writing the extraction logic — rendering
it raw would make every turn in a transcript dump the entire internal
prompt, which defeats "one command to share or archive an interaction."

The Markdown renderer splits on that marker to show just what was actually
said, and separately lifts out the `## Subconscious Signals` block (which
lives nowhere else in the data model) as its own section — so the issue's
explicit ask for signals inline is met without dumping the rest of the
internal scaffolding (continuity packet, injected memory/identity context).
`--json` stays the raw, unprocessed record for anyone who wants full
fidelity.

`[Correction]` events needed no special handling: the action-claim guardrail
already appends `"[Correction] ..."` directly into `result.text`/
`visible_text` (`core/agent_loop.py`), so it shows up verbatim in the reply
text with zero extra plumbing.

## Testing

```
pytest tests/db/test_agent_transcript.py tests/cli/test_transcript_cli.py \
       tests/db/test_agent_runtime.py tests/cli/test_cli.py -q
# 25 passed
ruff check apps/hexis_cli.py core/cli_api.py tests/db/test_agent_transcript.py tests/cli/test_transcript_cli.py
# All checks passed!
```

- `hexis migrate` applied cleanly against the running stack.
- `tests/db/test_agent_transcript.py`: session lookup + event-type filtering,
  heartbeat_id lookup, empty-result case, and last-N ordering — written to
  tolerate concurrent real activity from this DB's own live heartbeat/
  maintenance workers (asserts relative order of the test's own turns among
  whatever else is present, not an exact top-of-list turn).
- `tests/cli/test_transcript_cli.py`: end-to-end through the real `hexis`
  entrypoint, covering `--session` in both `--json` and `--md` (including
  the marker-stripping and Subconscious Signals extraction), `--last --json`,
  the no-matches message, and `--last`/`--session` mutual exclusivity.
- Manually verified `hexis transcript --last N` against real live turns in
  this environment, before and after the `user_message` extraction fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `hexis transcript` command to view agent conversations as Markdown or JSON.
  * Supports retrieving recent turns or transcripts for a specific session.
  * Includes messages, responses, tool activity, signals, status, energy usage, and execution details.
  * Clearly reports when no matching transcript is available or a turn remains unfinished.

* **Tests**
  * Added coverage for Markdown and JSON output, filtering, empty results, and invalid option combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->