### PR TITLE
Detect and surface worker code/schema version skew

### DIFF
--- a/apps/hexis_cli.py
+++ b/apps/hexis_cli.py
@@ -5393,6 +5393,21 @@ def _print_rich_status(p: dict[str, Any]) -> None:
             "[muted](the heartbeat only ticks while they are up — start them with `hexis up`)[/muted]"
         )
 
+    # Code/schema version skew (#113): a running worker's own bundled
+    # migrations predate what's actually applied to the DB it shares.
+    skew = p.get("worker_schema_skew") or {}
+    skewed_workers = skew.get("skewed_workers") or []
+    if skewed_workers:
+        names = ", ".join(
+            f"{w.get('mode', '?')}"
+            + (f"/{w.get('instance_name')}" if w.get("instance_name") else "")
+            for w in skewed_workers
+        )
+        console.print(
+            f"  [key]Schema   [/key] [warn]DB is at {skew.get('db_latest_migration')}; "
+            f"{names} predate it[/warn] [muted](run `hexis upgrade`)[/muted]"
+        )
+
     # Memory counts
     memories = p.get("memories", {})
     if memories:

--- a/core/agent_api.py
+++ b/core/agent_api.py
@@ -419,6 +419,32 @@ def read_build_id() -> str | None:
         return None
 
 
+def worker_code_stamp_metadata() -> dict[str, str]:
+    """Build/migration stamp for a worker's registration metadata (#113):
+    what code this process actually is, so `hexis status`/`hexis doctor` can
+    flag a running worker whose bundled db/migrations/ predates migrations
+    someone else already applied to the database it shares. Shared by every
+    worker kind (heartbeat/maintenance, channel) so the stamp means the same
+    thing everywhere. Never raises -- a worker must never fail to start
+    over a diagnostic stamp."""
+    metadata: dict[str, str] = {}
+    try:
+        build_id = read_build_id()
+        if build_id:
+            metadata["build_id"] = build_id
+    except Exception:
+        pass
+    try:
+        from core.migrations import latest_bundled_migration_version
+
+        bundled = latest_bundled_migration_version()
+        if bundled:
+            metadata["bundled_latest_migration"] = bundled
+    except Exception:
+        pass
+    return metadata
+
+
 async def record_build_change(conn, service: str) -> None:
     """Journal a 'my running code changed' entry (#93) when this service's
     build stamp differs from the last one it ran under. Advisory: never

--- a/core/cli_api.py
+++ b/core/cli_api.py
@@ -635,6 +635,45 @@ async def doctor_payload(
                 {"label": "Schema canonical", "status": "WARN", "detail": str(exc)}
             )
 
+        # 2c. Code/schema skew (#113): a running worker's own bundled
+        # migrations are older than what's actually applied to the DB it's
+        # sharing -- someone else (a newer image, a manual `hexis migrate`
+        # from a fresher checkout) moved the schema forward without it.
+        try:
+            skew_raw = await conn.fetchval("SELECT worker_code_schema_skew_report()")
+            skew = json.loads(skew_raw) if isinstance(skew_raw, str) else (skew_raw or {})
+            skewed_workers = skew.get("skewed_workers") or []
+            if skewed_workers:
+                names = ", ".join(
+                    f"{w.get('mode', '?')}"
+                    + (f"/{w.get('instance_name')}" if w.get("instance_name") else "")
+                    + f" (bundled {w.get('bundled_latest_migration', '?')})"
+                    for w in skewed_workers
+                )
+                checks.append(
+                    {
+                        "label": "Worker/schema version",
+                        "status": "WARN",
+                        "detail": (
+                            f"DB is now at {skew.get('db_latest_migration')}; "
+                            f"{len(skewed_workers)} running worker(s) predate it: {names}. "
+                            "Run `hexis upgrade` to rebuild and restart them."
+                        ),
+                    }
+                )
+            else:
+                checks.append(
+                    {
+                        "label": "Worker/schema version",
+                        "status": "OK",
+                        "detail": f"running workers match schema {skew.get('db_latest_migration') or '(none applied)'}",
+                    }
+                )
+        except Exception as exc:
+            checks.append(
+                {"label": "Worker/schema version", "status": "WARN", "detail": str(exc)}
+            )
+
         # 3. RabbitMQ (check config, not connectivity -- avoids dependency)
         try:
             rmq_url = await conn.fetchval(
@@ -1389,6 +1428,16 @@ async def status_payload_rich(
         except Exception:
             payload["workers"] = []
             payload["worker_tasks"] = []
+
+        # Code/schema version skew (#113): a running worker's own bundled
+        # migrations predate what's actually applied to the DB.
+        try:
+            skew_raw = await conn.fetchval("SELECT worker_code_schema_skew_report()")
+            payload["worker_schema_skew"] = (
+                json.loads(skew_raw) if isinstance(skew_raw, str) else (skew_raw or {})
+            )
+        except Exception:
+            payload["worker_schema_skew"] = {}
 
         return payload
     finally:

--- a/core/migrations.py
+++ b/core/migrations.py
@@ -129,6 +129,16 @@ def _list_migration_files(migrations_dir: Path) -> list[Path]:
     )
 
 
+def latest_bundled_migration_version(migrations_dir: Path | None = None) -> str | None:
+    """The highest-versioned migration file bundled in THIS process's own
+    db/migrations/ (#113). A worker records this at registration; comparing
+    it against schema_migrations' actual latest applied version is how
+    `hexis status`/`hexis doctor` detect a running worker whose code predates
+    migrations someone else already applied to the shared database."""
+    files = _list_migration_files(migrations_dir or MIGRATIONS_DIR)
+    return files[-1].stem if files else None
+
+
 def _migration_summary(sql: str) -> str:
     """First header-comment line of a migration — its own one-line story."""
     for line in sql.splitlines():

--- a/db/88_functions_worker_runtime.sql
+++ b/db/88_functions_worker_runtime.sql
@@ -407,3 +407,40 @@ BEGIN
     );
 END;
 $$ LANGUAGE plpgsql;
+
+-- Code/schema version skew (#113): a long-running worker keeps talking to a
+-- schema that has moved on without it -- migrations auto-apply on startup,
+-- but nothing previously checked or surfaced that the *running* worker code
+-- predates the migrations it's now sharing a database with. Each worker
+-- records the highest migration version bundled in its OWN db/migrations/
+-- at registration time (metadata.bundled_latest_migration); this compares
+-- that against the schema's actual latest applied version for every
+-- non-stale worker still running.
+CREATE OR REPLACE FUNCTION worker_code_schema_skew_report()
+RETURNS JSONB
+LANGUAGE sql STABLE
+AS $$
+    WITH latest AS (
+        SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1
+    ),
+    skewed AS (
+        SELECT
+            w.id AS worker_id,
+            w.mode,
+            w.instance_name,
+            w.build_id,
+            NULLIF(w.metadata->>'bundled_latest_migration', '') AS bundled_latest_migration,
+            (SELECT version FROM latest) AS db_latest_migration
+        FROM worker_runtime_status w
+        WHERE NOT w.is_stale
+          AND w.status IN ('starting', 'running', 'stopping')
+          AND NULLIF(w.metadata->>'bundled_latest_migration', '') IS NOT NULL
+          AND (SELECT version FROM latest) IS NOT NULL
+          AND NULLIF(w.metadata->>'bundled_latest_migration', '') < (SELECT version FROM latest)
+    )
+    SELECT jsonb_build_object(
+        'db_latest_migration', (SELECT version FROM latest),
+        'skewed_workers', COALESCE(jsonb_agg(to_jsonb(skewed)), '[]'::jsonb)
+    )
+    FROM skewed;
+$$;

--- a/db/migrations/0242_worker_code_schema_skew.sql
+++ b/db/migrations/0242_worker_code_schema_skew.sql
@@ -1,0 +1,39 @@
+-- Code/schema version skew detection (#113): migrations auto-apply on
+-- worker/API startup, but nothing previously checked or surfaced that a
+-- long-running worker's *code* predates migrations someone else (a fresher
+-- checkout's `hexis migrate`, or an already-restarted sibling worker) has
+-- since applied to the shared database. Each worker now records the highest
+-- migration version bundled in its own db/migrations/ at registration
+-- (metadata.bundled_latest_migration); this adds the read-only comparison
+-- `hexis status`/`hexis doctor` use to WARN when a running worker is behind.
+SET search_path = public, ag_catalog, "$user";
+SET check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION worker_code_schema_skew_report()
+RETURNS JSONB
+LANGUAGE sql STABLE
+AS $$
+    WITH latest AS (
+        SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1
+    ),
+    skewed AS (
+        SELECT
+            w.id AS worker_id,
+            w.mode,
+            w.instance_name,
+            w.build_id,
+            NULLIF(w.metadata->>'bundled_latest_migration', '') AS bundled_latest_migration,
+            (SELECT version FROM latest) AS db_latest_migration
+        FROM worker_runtime_status w
+        WHERE NOT w.is_stale
+          AND w.status IN ('starting', 'running', 'stopping')
+          AND NULLIF(w.metadata->>'bundled_latest_migration', '') IS NOT NULL
+          AND (SELECT version FROM latest) IS NOT NULL
+          AND NULLIF(w.metadata->>'bundled_latest_migration', '') < (SELECT version FROM latest)
+    )
+    SELECT jsonb_build_object(
+        'db_latest_migration', (SELECT version FROM latest),
+        'skewed_workers', COALESCE(jsonb_agg(to_jsonb(skewed)), '[]'::jsonb)
+    )
+    FROM skewed;
+$$;

--- a/services/channel_worker.py
+++ b/services/channel_worker.py
@@ -54,10 +54,13 @@ SUPPORTED_CHANNEL_TYPES = [
 
 
 def _worker_metadata() -> dict[str, Any]:
+    from core.agent_api import worker_code_stamp_metadata
+
     return {
         "process_id": os.getpid(),
         "host_name": socket.gethostname(),
         "command": "hexis-channels",
+        **worker_code_stamp_metadata(),
     }
 
 

--- a/services/worker_service.py
+++ b/services/worker_service.py
@@ -154,10 +154,13 @@ async def tee_outbox_to_web_inbox(
 
 
 def _worker_metadata() -> dict[str, Any]:
+    from core.agent_api import worker_code_stamp_metadata
+
     return {
         "process_id": os.getpid(),
         "host_name": socket.gethostname(),
         "command": "hexis-worker",
+        **worker_code_stamp_metadata(),
     }
 
 

--- a/tests/db/test_migrations.py
+++ b/tests/db/test_migrations.py
@@ -59,6 +59,31 @@ async def test_migrations_recorded_and_idempotent(db_pool):
         )
 
 
+def test_latest_bundled_migration_version_reads_real_migrations_dir():
+    """#113: the value a worker stamps onto its own registration metadata is
+    exactly the highest-versioned file in this checkout's db/migrations/."""
+    from core.migrations import _list_migration_files, latest_bundled_migration_version
+
+    files = _list_migration_files(_DB_ROOT / "migrations")
+    assert files, "expected at least one real migration on disk"
+    assert latest_bundled_migration_version(_DB_ROOT / "migrations") == files[-1].stem
+
+
+def test_latest_bundled_migration_version_missing_dir_returns_none(tmp_path):
+    from core.migrations import latest_bundled_migration_version
+
+    assert latest_bundled_migration_version(tmp_path / "does_not_exist") is None
+
+
+def test_latest_bundled_migration_version_orders_lexicographically(tmp_path):
+    (tmp_path / "0002_second.sql").write_text("-- second", encoding="utf-8")
+    (tmp_path / "0010_tenth.sql").write_text("-- tenth", encoding="utf-8")
+    (tmp_path / "0001_first.sql").write_text("-- first", encoding="utf-8")
+    from core.migrations import latest_bundled_migration_version
+
+    assert latest_bundled_migration_version(tmp_path) == "0010_tenth"
+
+
 async def test_applied_migration_checksum_drift_fails_loudly(db_pool):
     from core.migrations import (
         MigrationChecksumError,

--- a/tests/db/test_worker_code_schema_skew.py
+++ b/tests/db/test_worker_code_schema_skew.py
@@ -1,0 +1,128 @@
+"""Tests for worker_code_schema_skew_report() (db/88, migration 0242) -- the
+detection behind issue #113: a long-running worker's own bundled
+db/migrations/ predates what's actually applied to the DB it shares, and
+nothing previously checked or surfaced that in `hexis status`/`hexis doctor`.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.utils import get_test_identifier
+
+pytestmark = [pytest.mark.asyncio(loop_scope="session")]
+
+
+def _j(v):
+    return json.loads(v) if isinstance(v, str) else v
+
+
+async def _latest_migration_version(conn) -> str | None:
+    return await conn.fetchval("SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1")
+
+
+async def _register(conn, *, instance: str, bundled: str | None, status: str = "running"):
+    metadata = {"process_id": 1, "host_name": "test-host"}
+    if bundled is not None:
+        metadata["bundled_latest_migration"] = bundled
+    worker_id = await conn.fetchval(
+        "SELECT register_worker_instance('heartbeat', $1, $2::jsonb)",
+        instance,
+        json.dumps(metadata),
+    )
+    if status != "running":
+        await conn.execute(
+            "UPDATE worker_instances SET status = $1 WHERE id = $2::uuid", status, worker_id
+        )
+    return str(worker_id)  # report JSON encodes UUIDs as text
+
+
+async def test_no_skew_when_bundled_matches_latest(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            latest = await _latest_migration_version(conn)
+            instance = get_test_identifier("skew_match")
+            worker_id = await _register(conn, instance=instance, bundled=latest)
+
+            report = _j(await conn.fetchval("SELECT worker_code_schema_skew_report()"))
+            assert report["db_latest_migration"] == latest
+            assert worker_id not in [w["worker_id"] for w in report["skewed_workers"]]
+        finally:
+            await tr.rollback()
+
+
+async def test_skew_detected_for_worker_with_older_bundle(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            instance = get_test_identifier("skew_old")
+            worker_id = await _register(conn, instance=instance, bundled="0001_fake_old")
+
+            report = _j(await conn.fetchval("SELECT worker_code_schema_skew_report()"))
+            skewed = {w["worker_id"]: w for w in report["skewed_workers"]}
+            assert worker_id in skewed
+            entry = skewed[worker_id]
+            assert entry["mode"] == "heartbeat"
+            assert entry["instance_name"] == instance
+            assert entry["bundled_latest_migration"] == "0001_fake_old"
+            assert entry["db_latest_migration"] == report["db_latest_migration"]
+        finally:
+            await tr.rollback()
+
+
+async def test_worker_without_bundled_version_is_not_flagged(db_pool):
+    # A worker that has never reported its bundled migration (older Hexis
+    # build, before #113 landed) is a known-unknown, not a confirmed skew --
+    # asserting skew we can't actually verify would be worse than silence.
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            instance = get_test_identifier("skew_unknown")
+            worker_id = await _register(conn, instance=instance, bundled=None)
+
+            report = _j(await conn.fetchval("SELECT worker_code_schema_skew_report()"))
+            assert worker_id not in [w["worker_id"] for w in report["skewed_workers"]]
+        finally:
+            await tr.rollback()
+
+
+async def test_stale_worker_is_not_flagged(db_pool):
+    # A worker that stopped heartbeating is already covered by the separate
+    # staleness check; re-flagging it here would just be noise.
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            instance = get_test_identifier("skew_stale")
+            worker_id = await _register(conn, instance=instance, bundled="0001_fake_old")
+            await conn.execute(
+                "UPDATE worker_instances SET last_seen_at = CURRENT_TIMESTAMP - INTERVAL '10 minutes' "
+                "WHERE id = $1::uuid",
+                worker_id,
+            )
+
+            report = _j(await conn.fetchval("SELECT worker_code_schema_skew_report()"))
+            assert worker_id not in [w["worker_id"] for w in report["skewed_workers"]]
+        finally:
+            await tr.rollback()
+
+
+async def test_stopped_worker_is_not_flagged(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            instance = get_test_identifier("skew_stopped")
+            worker_id = await _register(
+                conn, instance=instance, bundled="0001_fake_old", status="stopped"
+            )
+
+            report = _j(await conn.fetchval("SELECT worker_code_schema_skew_report()"))
+            assert worker_id not in [w["worker_id"] for w in report["skewed_workers"]]
+        finally:
+            await tr.rollback()


### PR DESCRIPTION
Fixes #113.

## What

Migrations auto-apply on worker/API startup, but nothing checked or
surfaced that a long-running worker's own *code* had fallen behind
migrations someone else already applied to the shared database. The
issue's own case: two heartbeat-repair commits landed and migrated the
schema forward while containers built days earlier kept serving stale code
against it — silently, until someone read the logs and connected the dots.

- `core/migrations.py`: `latest_bundled_migration_version()` — the highest-
  versioned migration file bundled in *this* process's own `db/migrations/`.
- `core/agent_api.py`: `worker_code_stamp_metadata()` — a shared, never-
  raising helper both worker kinds call at registration to stamp `build_id`
  (the existing #93 image stamp — collected before, but never actually wired
  into `worker_instances.build_id`) and `bundled_latest_migration` into
  their registration metadata.
- `services/worker_service.py` + `services/channel_worker.py` each had
  their own `_worker_metadata()`; both now include the shared stamp.
- db/88 + migration 0242: `worker_code_schema_skew_report()` compares every
  non-stale, still-running worker's `bundled_latest_migration` against
  `schema_migrations`' actual latest applied version. A worker that never
  reported the field (an older Hexis build, pre-#113) is a known-unknown,
  not asserted as skewed — there's nothing to verify it against.
- `hexis doctor`: new **"Worker/schema version"** check, WARNing with close
  to the message shape the issue itself suggested: *"DB is now at 0242; N
  running worker(s) predate it: ... — run `hexis upgrade`."*
- `hexis status`: a **"Schema"** line appears only when skew is real (silent
  otherwise, so the common case gets zero extra noise).

## Verified live, not just unit-tested

Manually inserted a `worker_instances` row stamped with an old
`bundled_latest_migration` against this environment's real running stack,
confirmed both `hexis doctor` and `hexis status` render the WARN with the
right detail, then confirmed it clears once that row is removed:

```
│⚠   │ Worker/schema version │ DB is now at 0242_worker_code_schema_skew; 1    │
│    │                       │ running worker(s) predate it: heartbeat/stale-  │
...
  Schema    DB is at 0242_worker_code_schema_skew; heartbeat/stale-sim predate it
```

## Testing

```
pytest tests/db/test_worker_code_schema_skew.py -q
# 5 passed
pytest tests/db/test_migrations.py -k latest_bundled -q
# 3 passed
pytest tests/db/test_worker_observability.py tests/services/test_worker_observability.py \
       tests/db/test_tool_reachability_audit.py tests/db/test_consent_coherence.py \
       tests/core/test_pwa_access.py -q
# 21 passed -- no regressions from the _worker_metadata()/doctor_payload/
# status_payload_rich changes
ruff check <changed files>
# All checks passed!
```

- `tests/db/test_worker_code_schema_skew.py`: matching bundle → no skew;
  older bundle → flagged with correct fields; a worker that never reported
  the field → not flagged; a stale worker → not flagged; a stopped worker
  → not flagged.
- `hexis migrate` applied cleanly against the running stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detection for workers running code that is older than the database schema.
  - Worker status information now includes version details to support compatibility checks.

- **Bug Fixes**
  - `hexis status` now warns when workers are behind the applied database migrations and identifies affected workers.
  - `hexis doctor` reports schema compatibility as either healthy or requiring attention.

- **Documentation**
  - Warnings instruct operators to run `hexis upgrade` when a version mismatch is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->