### PR TITLE
Recover Gmail sync: ongoing polling + self-continuing backfill

### DIFF
--- a/db/77_functions_integrations.sql
+++ b/db/77_functions_integrations.sql
@@ -147,6 +147,11 @@ INSERT INTO config_defaults (key, value, description) VALUES
         'integrations.gmail.heartbeat_digest_enabled',
         'false'::jsonb,
         'Controls whether heartbeat may proactively check connected Gmail for digests or important messages without a live user turn.'
+    ),
+    (
+        'integrations.gmail.ambient_poll_interval_seconds',
+        '900'::jsonb,
+        'How often the ongoing-sync ambient responsibility (#110) re-checks Gmail for new messages after a backfill runs.'
     )
 ON CONFLICT (key) DO UPDATE SET
     value = EXCLUDED.value,

--- a/db/79_functions_connector_backfill.sql
+++ b/db/79_functions_connector_backfill.sql
@@ -200,6 +200,62 @@ BEGIN
 END;
 $$;
 
+-- Ongoing sync (#110): a one-shot backfill only ever ingests the first page
+-- it's asked for. This is the "keep watching after the backfill" half --
+-- an ambient_responsibilities row with a gmail source, evaluated on the
+-- normal ambient poll cadence (services/ambient_responsibilities.py's
+-- _evaluate_gmail, already implemented, was just never given anything to
+-- watch). Idempotent: returns the existing row if one already covers this
+-- account. Never raises -- an ambient-responsibility hiccup must not block
+-- the backfill that's actually being requested.
+CREATE OR REPLACE FUNCTION ensure_gmail_ambient_responsibility(
+    p_account_key TEXT
+) RETURNS UUID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_key TEXT := lower(COALESCE(NULLIF(btrim(p_account_key), ''), ''));
+    v_id UUID;
+    v_result JSONB;
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_proc WHERE proname = 'create_ambient_responsibility'
+    ) THEN
+        RETURN NULL;  -- ambient_responsibilities not migrated in yet
+    END IF;
+
+    SELECT id INTO v_id
+    FROM ambient_responsibilities
+    WHERE status IN ('active', 'proposed', 'paused', 'blocked')
+      AND sources @> jsonb_build_array(
+          jsonb_build_object('connector_id', 'gmail', 'account_key', v_key)
+      )
+    LIMIT 1;
+    IF v_id IS NOT NULL THEN
+        RETURN v_id;
+    END IF;
+
+    v_result := create_ambient_responsibility(jsonb_build_object(
+        'title', 'Ongoing Gmail sync',
+        'user_intent', 'Keep ingesting new Gmail messages as they arrive, so memory of email stays current without a manual re-backfill.',
+        'kind', 'monitor',
+        'created_by', 'system',
+        'memory_policy', 'task_scoped',
+        'sources', jsonb_build_array(
+            jsonb_build_object('connector_id', 'gmail', 'account_key', v_key)
+        ),
+        'trigger', jsonb_build_object(
+            'kind', 'interval',
+            'every_seconds', COALESCE(get_config_int('integrations.gmail.ambient_poll_interval_seconds'), 900)
+        )
+    ));
+    RETURN NULLIF(v_result->'output'->>'responsibility_id', '')::uuid;
+EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'ensure_gmail_ambient_responsibility failed for %: %', v_key, SQLERRM;
+    RETURN NULL;
+END;
+$$;
+
 CREATE OR REPLACE FUNCTION enqueue_connector_backfill_job(
     p_connector_id TEXT,
     p_account_key TEXT,
@@ -223,6 +279,9 @@ BEGIN
         normalized_cursor,
         COALESCE(p_metadata, '{}'::jsonb)
     );
+    IF row_connection.connector_id = 'gmail' THEN
+        PERFORM ensure_gmail_ambient_responsibility(row_connection.account_key);
+    END IF;
 
     SELECT id
     INTO existing_id
@@ -570,6 +629,25 @@ BEGIN
         updated_at = CURRENT_TIMESTAMP
     WHERE connection_id = row_job.connection_id
       AND cursor_key = row_job.cursor_key;
+
+    -- Self-continuing backfill (#110): a capped job (max_messages) that hit
+    -- its cap and still has a page_token left (result.truncated) previously
+    -- just sat there "completed" forever -- nothing re-picked it up, so a
+    -- one-shot 100-message backfill was permanent. The cursor above already
+    -- carries the page_token forward; this just makes sure a job exists to
+    -- consume it on the next maintenance tick. enqueue_connector_backfill_job
+    -- is idempotent (one active job per connection+cursor_key), so this is
+    -- safe even if something else already queued a successor.
+    IF COALESCE((p_result->>'truncated')::boolean, FALSE) THEN
+        PERFORM enqueue_connector_backfill_job(
+            row_job.connector_id,
+            row_job.account_key,
+            row_job.cursor_key,
+            row_job.requested_range,
+            row_job.metadata,
+            row_job.max_attempts
+        );
+    END IF;
 
     RETURN jsonb_build_object(
         'job_id', row_job.id::text,

--- a/db/migrations/0246_gmail_ongoing_sync.sql
+++ b/db/migrations/0246_gmail_ongoing_sync.sql
@@ -1,0 +1,245 @@
+-- Gmail sync recovery (#110): a one-shot backfill (default max_messages=100)
+-- previously completed "truncated" and just sat there forever -- nothing
+-- re-enqueued a successor, and no ongoing sync mechanism was ever populated
+-- (the ambient_responsibilities Gmail evaluator has been fully implemented
+-- since services/ambient_responsibilities.py landed, but zero rows ever
+-- existed to invoke it). This closes both recovery paths named in the issue:
+--   (a) auto-create the ongoing-sync ambient responsibility whenever a
+--       Gmail backfill is queued, and
+--   (b) re-enqueue a successor job when a completed job reports truncated.
+-- True incremental sync via Gmail's history.list API (the issue's third,
+-- larger suggested fix) is not attempted here -- it's a bigger design/testing
+-- effort on its own. The ambient responsibility's poll query already scopes
+-- to messages after the last check, so this closes the "stuck forever" bug
+-- even without it.
+SET search_path = public, ag_catalog, "$user";
+SET check_function_bodies = off;
+
+INSERT INTO config_defaults (key, value, description) VALUES
+    (
+        'integrations.gmail.ambient_poll_interval_seconds',
+        '900'::jsonb,
+        'How often the ongoing-sync ambient responsibility (#110) re-checks Gmail for new messages after a backfill runs.'
+    )
+ON CONFLICT (key) DO UPDATE SET
+    value = EXCLUDED.value,
+    description = EXCLUDED.description,
+    updated_at = CURRENT_TIMESTAMP;
+
+-- Ongoing sync (#110): a one-shot backfill only ever ingests the first page
+-- it's asked for. This is the "keep watching after the backfill" half --
+-- an ambient_responsibilities row with a gmail source, evaluated on the
+-- normal ambient poll cadence (services/ambient_responsibilities.py's
+-- _evaluate_gmail, already implemented, was just never given anything to
+-- watch). Idempotent: returns the existing row if one already covers this
+-- account. Never raises -- an ambient-responsibility hiccup must not block
+-- the backfill that's actually being requested.
+CREATE OR REPLACE FUNCTION ensure_gmail_ambient_responsibility(
+    p_account_key TEXT
+) RETURNS UUID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_key TEXT := lower(COALESCE(NULLIF(btrim(p_account_key), ''), ''));
+    v_id UUID;
+    v_result JSONB;
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_proc WHERE proname = 'create_ambient_responsibility'
+    ) THEN
+        RETURN NULL;  -- ambient_responsibilities not migrated in yet
+    END IF;
+
+    SELECT id INTO v_id
+    FROM ambient_responsibilities
+    WHERE status IN ('active', 'proposed', 'paused', 'blocked')
+      AND sources @> jsonb_build_array(
+          jsonb_build_object('connector_id', 'gmail', 'account_key', v_key)
+      )
+    LIMIT 1;
+    IF v_id IS NOT NULL THEN
+        RETURN v_id;
+    END IF;
+
+    v_result := create_ambient_responsibility(jsonb_build_object(
+        'title', 'Ongoing Gmail sync',
+        'user_intent', 'Keep ingesting new Gmail messages as they arrive, so memory of email stays current without a manual re-backfill.',
+        'kind', 'monitor',
+        'created_by', 'system',
+        'memory_policy', 'task_scoped',
+        'sources', jsonb_build_array(
+            jsonb_build_object('connector_id', 'gmail', 'account_key', v_key)
+        ),
+        'trigger', jsonb_build_object(
+            'kind', 'interval',
+            'every_seconds', COALESCE(get_config_int('integrations.gmail.ambient_poll_interval_seconds'), 900)
+        )
+    ));
+    RETURN NULLIF(v_result->'output'->>'responsibility_id', '')::uuid;
+EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'ensure_gmail_ambient_responsibility failed for %: %', v_key, SQLERRM;
+    RETURN NULL;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION enqueue_connector_backfill_job(
+    p_connector_id TEXT,
+    p_account_key TEXT,
+    p_cursor_key TEXT DEFAULT 'messages',
+    p_requested_range JSONB DEFAULT '{}'::jsonb,
+    p_metadata JSONB DEFAULT '{}'::jsonb,
+    p_max_attempts INT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    row_connection integration_connections%ROWTYPE;
+    row_job connector_backfill_jobs%ROWTYPE;
+    normalized_cursor TEXT := COALESCE(NULLIF(btrim(p_cursor_key), ''), 'messages');
+    existing_id UUID;
+BEGIN
+    row_connection := _connector_connection(p_connector_id, p_account_key);
+    PERFORM ensure_connector_cursor(
+        row_connection.connector_id,
+        row_connection.account_key,
+        normalized_cursor,
+        COALESCE(p_metadata, '{}'::jsonb)
+    );
+    IF row_connection.connector_id = 'gmail' THEN
+        PERFORM ensure_gmail_ambient_responsibility(row_connection.account_key);
+    END IF;
+
+    SELECT id
+    INTO existing_id
+    FROM connector_backfill_jobs
+    WHERE connection_id = row_connection.id
+      AND cursor_key = normalized_cursor
+      AND status IN ('pending', 'in_progress', 'paused')
+    ORDER BY created_at DESC
+    LIMIT 1;
+
+    IF existing_id IS NOT NULL THEN
+        SELECT * INTO row_job FROM connector_backfill_jobs WHERE id = existing_id;
+        RETURN jsonb_build_object(
+            'job_id', row_job.id::text,
+            'existing', TRUE,
+            'status', row_job.status,
+            'connector_id', row_job.connector_id,
+            'account_key', row_job.account_key,
+            'cursor_key', row_job.cursor_key,
+            'requested_range', row_job.requested_range,
+            'estimate', estimate_connector_backfill(row_job.connector_id, row_job.requested_range),
+            'progress', row_job.progress
+        );
+    END IF;
+
+    INSERT INTO connector_backfill_jobs (
+        connection_id,
+        connector_id,
+        account_key,
+        cursor_key,
+        requested_range,
+        metadata,
+        max_attempts
+    )
+    VALUES (
+        row_connection.id,
+        row_connection.connector_id,
+        row_connection.account_key,
+        normalized_cursor,
+        COALESCE(p_requested_range, '{}'::jsonb),
+        COALESCE(p_metadata, '{}'::jsonb),
+        GREATEST(COALESCE(p_max_attempts, 3), 1)
+    )
+    RETURNING * INTO row_job;
+
+    RETURN jsonb_build_object(
+        'job_id', row_job.id::text,
+        'existing', FALSE,
+        'status', row_job.status,
+        'connector_id', row_job.connector_id,
+        'account_key', row_job.account_key,
+        'cursor_key', row_job.cursor_key,
+        'requested_range', row_job.requested_range,
+        'estimate', estimate_connector_backfill(row_job.connector_id, row_job.requested_range),
+        'progress', row_job.progress,
+        'next_attempt_at', row_job.next_attempt_at
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION complete_connector_backfill_job(
+    p_job_id UUID,
+    p_result JSONB DEFAULT '{}'::jsonb,
+    p_cursor_value JSONB DEFAULT NULL,
+    p_high_watermark TIMESTAMPTZ DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    row_job connector_backfill_jobs%ROWTYPE;
+BEGIN
+    SELECT *
+    INTO row_job
+    FROM connector_backfill_jobs
+    WHERE id = p_job_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object('job_id', p_job_id::text, 'status', 'missing');
+    END IF;
+
+    IF p_cursor_value IS NOT NULL AND p_cursor_value <> 'null'::jsonb THEN
+        PERFORM advance_connector_cursor(
+            row_job.connector_id,
+            row_job.account_key,
+            row_job.cursor_key,
+            p_cursor_value,
+            p_high_watermark,
+            jsonb_build_object('completed_by_job_id', p_job_id::text)
+        );
+    END IF;
+
+    UPDATE connector_backfill_jobs
+    SET status = 'completed',
+        result = COALESCE(p_result, '{}'::jsonb),
+        error = NULL,
+        completed_at = CURRENT_TIMESTAMP,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE id = p_job_id
+    RETURNING * INTO row_job;
+
+    UPDATE connector_sync_cursors
+    SET status = 'active',
+        last_completed_at = CURRENT_TIMESTAMP,
+        last_error = NULL,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE connection_id = row_job.connection_id
+      AND cursor_key = row_job.cursor_key;
+
+    -- Self-continuing backfill (#110): a capped job (max_messages) that hit
+    -- its cap and still has a page_token left (result.truncated) previously
+    -- just sat there "completed" forever -- nothing re-picked it up, so a
+    -- one-shot 100-message backfill was permanent. The cursor above already
+    -- carries the page_token forward; this just makes sure a job exists to
+    -- consume it on the next maintenance tick. enqueue_connector_backfill_job
+    -- is idempotent (one active job per connection+cursor_key), so this is
+    -- safe even if something else already queued a successor.
+    IF COALESCE((p_result->>'truncated')::boolean, FALSE) THEN
+        PERFORM enqueue_connector_backfill_job(
+            row_job.connector_id,
+            row_job.account_key,
+            row_job.cursor_key,
+            row_job.requested_range,
+            row_job.metadata,
+            row_job.max_attempts
+        );
+    END IF;
+
+    RETURN jsonb_build_object(
+        'job_id', row_job.id::text,
+        'status', row_job.status,
+        'result', row_job.result
+    );
+END;
+$$;

--- a/tests/db/test_connector_backfill.py
+++ b/tests/db/test_connector_backfill.py
@@ -118,6 +118,134 @@ async def test_connector_backfill_job_cursor_lifecycle(db_pool):
     assert status["jobs"][0]["status"] == "completed"
 
 
+async def test_enqueue_gmail_backfill_creates_ongoing_sync_responsibility(db_pool):
+    """#110: a Gmail backfill previously had no ongoing-sync mechanism --
+    the ambient responsibility evaluator was fully implemented but nothing
+    ever created a row for it to evaluate. Enqueuing a backfill now ensures
+    one exists, idempotently."""
+    marker = get_test_identifier("connector-ambient")
+
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            account = await _connected_gmail(conn, marker)
+            await conn.fetchval(
+                "SELECT enqueue_connector_backfill_job('gmail', $1, 'messages')",
+                account,
+            )
+
+            rows = await conn.fetch(
+                """
+                SELECT id, status, sources FROM ambient_responsibilities
+                WHERE sources @> jsonb_build_array(
+                    jsonb_build_object('connector_id', 'gmail', 'account_key', $1::text)
+                )
+                """,
+                account.lower(),
+            )
+            assert len(rows) == 1
+            assert rows[0]["status"] in ("active", "proposed", "blocked")
+
+            # A second backfill for the same account must not duplicate it.
+            await conn.fetchval(
+                "SELECT enqueue_connector_backfill_job('gmail', $1, 'messages')",
+                account,
+            )
+            rows_again = await conn.fetch(
+                """
+                SELECT id FROM ambient_responsibilities
+                WHERE sources @> jsonb_build_array(
+                    jsonb_build_object('connector_id', 'gmail', 'account_key', $1::text)
+                )
+                """,
+                account.lower(),
+            )
+            assert len(rows_again) == 1
+            assert rows_again[0]["id"] == rows[0]["id"]
+        finally:
+            await tr.rollback()
+
+
+async def test_completed_truncated_job_reenqueues_successor(db_pool):
+    """#110: a capped backfill that hit max_messages and still had a
+    page_token left previously completed and just sat there forever.
+    Completing with result.truncated=true must queue a successor so the
+    next maintenance tick continues from the advanced cursor."""
+    marker = get_test_identifier("connector-truncated")
+
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            account = await _connected_gmail(conn, marker)
+            job = _j(await conn.fetchval(
+                "SELECT enqueue_connector_backfill_job('gmail', $1, 'messages')",
+                account,
+            ))
+            await conn.fetchval("SELECT claim_connector_backfill_jobs_for('gmail', 5)")
+
+            completed = _j(await conn.fetchval(
+                """
+                SELECT complete_connector_backfill_job(
+                    $1::uuid,
+                    '{"items_seen": 100, "truncated": true, "next_page_token": "page-2"}'::jsonb,
+                    '{"page_token": "page-2"}'::jsonb,
+                    CURRENT_TIMESTAMP
+                )
+                """,
+                job["job_id"],
+            ))
+            assert completed["status"] == "completed"
+
+            status = _j(await conn.fetchval(
+                "SELECT get_connector_backfill_status('gmail', $1)", account
+            ))
+            statuses = {j["job_id"]: j["status"] for j in status["jobs"]}
+            assert statuses[job["job_id"]] == "completed"
+            successors = [
+                jid for jid, st in statuses.items()
+                if jid != job["job_id"] and st == "pending"
+            ]
+            assert len(successors) == 1, statuses
+            assert status["cursors"][0]["cursor_value"] == {"page_token": "page-2"}
+        finally:
+            await tr.rollback()
+
+
+async def test_completed_non_truncated_job_has_no_successor(db_pool):
+    marker = get_test_identifier("connector-finished")
+
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            account = await _connected_gmail(conn, marker)
+            job = _j(await conn.fetchval(
+                "SELECT enqueue_connector_backfill_job('gmail', $1, 'messages')",
+                account,
+            ))
+            await conn.fetchval("SELECT claim_connector_backfill_jobs_for('gmail', 5)")
+            await conn.fetchval(
+                """
+                SELECT complete_connector_backfill_job(
+                    $1::uuid,
+                    '{"items_seen": 3, "truncated": false}'::jsonb,
+                    '{"page_token": null}'::jsonb,
+                    CURRENT_TIMESTAMP
+                )
+                """,
+                job["job_id"],
+            )
+
+            status = _j(await conn.fetchval(
+                "SELECT get_connector_backfill_status('gmail', $1)", account
+            ))
+            assert len(status["jobs"]) == 1
+        finally:
+            await tr.rollback()
+
+
 async def test_connector_backfill_pause_resume_and_cancel(db_pool):
     marker = get_test_identifier("connector-pause")
 

--- a/tests/services/test_gmail_backfill.py
+++ b/tests/services/test_gmail_backfill.py
@@ -176,11 +176,18 @@ async def test_run_gmail_backfill_step_stores_source_documents_and_ingestion_job
         ))
 
     assert handled == 1
-    assert status["jobs"][0]["job_id"] == job["job_id"]
-    assert status["jobs"][0]["status"] == "completed"
-    assert status["jobs"][0]["result"]["items_stored"] == 2
-    assert status["jobs"][0]["result"]["truncated"] is True
+    jobs_by_id = {j["job_id"]: j for j in status["jobs"]}
+    original = jobs_by_id[job["job_id"]]
+    assert original["status"] == "completed"
+    assert original["result"]["items_stored"] == 2
+    assert original["result"]["truncated"] is True
     assert status["cursors"][0]["cursor_value"]["page_token"] == "next-page"
+    # #110: a truncated completion now self-continues -- a pending successor
+    # job is queued so the next maintenance tick picks up at "next-page"
+    # instead of a capped backfill silently completing forever.
+    successors = [j for jid, j in jobs_by_id.items() if jid != job["job_id"]]
+    assert len(successors) == 1
+    assert successors[0]["status"] == "pending"
     assert [row["provider_item_id"] for row in items] == ["msg-1", "msg-2"]
     assert items[0]["ingestion_job_id"] is not None
     assert _j(items[0]["raw_metadata"])["gmail_history_id"] == "history-msg-1"


### PR DESCRIPTION
Addresses #110 (does not fully close it — see "Not attempted" below).

Verified the full causal chain from the issue against the current codebase
before touching anything:

- A Gmail backfill capped at `max_messages=100` completes with `truncated:
  true` and a leftover `page_token`, but nothing re-enqueues a successor —
  confirmed `complete_connector_backfill_job` unconditionally marks the job
  `'completed'` with no truncation check.
- No incremental sync exists — confirmed nothing anywhere calls Gmail's
  `history.list`, despite `history_id` being faithfully written to the
  cursor on every completion (write-only dead state).
- `ambient_responsibilities`, the intended ongoing-sync mechanism, had zero
  rows — confirmed `services/connector_setup.py` has no reference to
  `manage_responsibility`/`create_ambient_responsibility`, exactly as the
  issue says — even though `services/ambient_responsibilities.py`'s
  `_evaluate_gmail` is a real, complete implementation: it calls the Gmail
  API directly with an `after:<last_checked_at>` query and upserts new
  `connector_source_items`.

## What this implements — the two most direct of the four suggested fixes

### (a) Auto-create the ongoing-sync responsibility
New `ensure_gmail_ambient_responsibility(account_key)`, called from
`enqueue_connector_backfill_job` whenever the connector is `'gmail'` — so
every path that starts a Gmail backfill (the chat/MCP tool, and this PR's
own re-enqueue below) also guarantees the poller that keeps checking for
new mail afterward. Idempotent (checks for an existing responsibility with
a matching gmail source first) and non-blocking (wrapped so a failure here
can never block the backfill actually being requested).

### (b) Self-continuing backfill
`complete_connector_backfill_job` now re-enqueues a successor via the same
idempotent `enqueue_connector_backfill_job` whenever `result.truncated` is
true. The cursor (with the correct `page_token`) is already advanced
earlier in the same function; this just makes sure a job exists to consume
it on the next maintenance tick, so a capped backfill keeps paging forward
instead of completing once and going silent forever.

## Not attempted

**(c) True incremental sync via Gmail's `history.list` API.** That's a
bigger, separate effort (handling the "historyId too old" 404 requiring a
full re-backfill, pagination semantics, etc.) that deserves its own careful
pass. The ambient responsibility's `after:<date>` query already scopes each
poll to new-ish mail, which closes the "stuck forever" bug even without
true incremental diffing — less precise, but a real, working fix rather
than nothing.

**(d) A dedicated observability surface for silent no-ops.** (a)+(b)
together remove the silent-no-op condition at its root, so a separate
staleness alarm felt like effort better spent verifying the real fix than
guarding against a bug this PR already closes.

Both baseline (`db/77`, `db/79`) and a new migration (0246) carry the same
function bodies, so a fresh install and an already-migrated database (like
this environment's own) converge to the same behavior.

## Testing

```
pytest tests/db/test_connector_backfill.py tests/db/test_portable_brain_contract.py \
       tests/services/test_channel_backfill.py tests/services/test_gmail_backfill.py \
       tests/services/test_ambient_responsibilities.py -q
# 19 passed
ruff check <changed .py files>
# All checks passed!
```

- `tests/db/test_connector_backfill.py`: two new tests — a Gmail backfill
  enqueue creates exactly one ongoing-sync responsibility (and a second
  enqueue doesn't duplicate it), and a truncated completion queues exactly
  one pending successor (a non-truncated one does not).
- `tests/services/test_gmail_backfill.py`: updated the existing
  truncated-completion test's assertions — it now correctly expects two
  jobs (original completed + new pending successor) instead of asserting
  the original is the only one, which was this PR's one real behavior
  change to an existing test rather than a new gap.
- `hexis migrate` applied cleanly against the running stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Gmail synchronization now continues automatically after backfills, including truncated results.
  - Follow-up backfill jobs resume from the correct page during the next maintenance cycle.
  - Gmail ambient synchronization checks for new messages every 15 minutes.

- **Bug Fixes**
  - Prevented ongoing Gmail synchronization from stopping after a one-time backfill.
  - Repeated backfill scheduling avoids creating duplicate ongoing-sync responsibilities.

- **Tests**
  - Added coverage for Gmail sync recovery, continuation, and non-truncated completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->