### PR TITLE
Replace GitHub Issues env-var dead-end with a productized setup flow

### DIFF
--- a/apps/cli_auth.py
+++ b/apps/cli_auth.py
@@ -68,6 +68,23 @@ def register_auth_subparsers(
         ("--client-id", {"default": None, "help": "Override Chutes client ID"}),
     ])
 
+    # ── GitHub (Issues, via a fine-grained/classic PAT) (#102) ────
+    gh = auth_sub.add_parser(
+        "github", parents=[db_parent],
+        help="GitHub API for the github-issues skill (personal access token)",
+    )
+    gh_sub = gh.add_subparsers(dest="github_command")
+    _ghst = gh_sub.add_parser("setup-token", parents=[db_parent], help="Paste a personal access token")
+    _ghst.add_argument("--token", default=None, help="Token value (prompted if omitted)")
+    _ghst.set_defaults(func="auth_github_setup_token")
+    _ghs = gh_sub.add_parser("status", parents=[db_parent], help="Show token status")
+    _ghs.add_argument("--json", action="store_true", help="Output JSON")
+    _ghs.set_defaults(func="auth_github_status")
+    _ghl = gh_sub.add_parser("logout", parents=[db_parent], help="Delete stored credentials")
+    _ghl.add_argument("--yes", "-y", action="store_true", help="Skip confirmation")
+    _ghl.set_defaults(func="auth_github_logout")
+    gh.set_defaults(func="auth_github")
+
     # ── GitHub Copilot ────────────────────────────────────────────
     ghc = auth_sub.add_parser("github-copilot", parents=[db_parent], help="GitHub Copilot (device code)")
     ghc_sub = ghc.add_subparsers(dest="github_copilot_command")
@@ -177,6 +194,16 @@ def dispatch_auth_command(func: str, args: Any, dsn: str) -> int | None:
         return asyncio.run(_anthropic_status(dsn, ws, as_json=bool(getattr(args, "json", False))))
     if func == "auth_anthropic_logout":
         return asyncio.run(_anthropic_logout(dsn, ws, getattr(args, "yes", False)))
+
+    # ── GitHub (#102) ──
+    if func == "auth_github":
+        return asyncio.run(_github_status(dsn, ws, as_json=False))
+    if func == "auth_github_setup_token":
+        return asyncio.run(_github_setup_token(dsn, ws, getattr(args, "token", None)))
+    if func == "auth_github_status":
+        return asyncio.run(_github_status(dsn, ws, as_json=bool(getattr(args, "json", False))))
+    if func == "auth_github_logout":
+        return asyncio.run(_github_logout(dsn, ws, getattr(args, "yes", False)))
 
     # ── Chutes ──
     if func == "auth_chutes":
@@ -720,6 +747,94 @@ async def _anthropic_logout(dsn: str, wait_seconds: int, yes: bool) -> int:
     # Also clear any credential left behind by the removed OAuth login flow.
     delete_auth("oauth.anthropic")
     console.print("[ok]Deleted Anthropic credentials.[/ok]")
+    return 0
+
+
+async def _github_setup_token(dsn: str, wait_seconds: int, token: str | None) -> int:
+    """#102: the github-issues skill dead-ended into "set
+    GITHUB_PERSONAL_ACCESS_TOKEN in the service environment". This is the
+    interim, productized replacement the issue's own Non-Goals sanction: a
+    terminal-only prompt (never chat), verified against GitHub's own API
+    before being stored, so a bad paste fails loudly here instead of at
+    skill-activation time."""
+    import getpass
+
+    from apps.cli_theme import console
+    from core.auth.github_pat import (
+        GithubPatCredentials,
+        save_credentials,
+        validate_pat_format,
+        verify_pat,
+    )
+
+    if not token:
+        console.print(
+            "[dim]Create a fine-grained token scoped to Issues (read/write) on the "
+            "target repo(s) at https://github.com/settings/personal-access-tokens/new[/dim]"
+        )
+        try:
+            token = getpass.getpass("Paste your GitHub personal access token: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            console.print("\n[dim]Aborted.[/dim]")
+            return 1
+
+    error = validate_pat_format(token)
+    if error:
+        _print_err(f"Invalid token: {error}")
+        return 1
+
+    login, verify_error = await verify_pat(token)
+    if verify_error:
+        _print_err(f"Could not verify token: {verify_error}")
+        return 1
+
+    save_credentials(GithubPatCredentials(token=token, login=login))
+    console.print(f"[ok]GitHub token saved and verified as @{login}.[/ok]")
+    return 0
+
+
+async def _github_status(dsn: str, wait_seconds: int, *, as_json: bool) -> int:
+    from core.auth.github_pat import load_credentials
+
+    creds = load_credentials()
+    if not creds:
+        if as_json:
+            sys.stdout.write(json.dumps({"configured": False}, indent=2) + "\n")
+        else:
+            sys.stdout.write("GitHub: not configured. Run `hexis auth github setup-token`.\n")
+        return 0
+
+    redacted = creds.token[:12] + "..." if len(creds.token) > 12 else "***"
+    if as_json:
+        sys.stdout.write(
+            json.dumps(
+                {"configured": True, "login": creds.login, "token_prefix": redacted},
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+    else:
+        sys.stdout.write(f"GitHub: configured as @{creds.login} ({redacted})\n")
+    return 0
+
+
+async def _github_logout(dsn: str, wait_seconds: int, yes: bool) -> int:
+    from apps.cli_theme import console
+    from core.auth.github_pat import delete_credentials
+
+    if not yes:
+        try:
+            answer = input("Delete stored GitHub credentials? Type 'yes' to confirm: ").strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            console.print("\n[dim]Aborted.[/dim]")
+            return 1
+        if answer != "yes":
+            console.print("[dim]Aborted.[/dim]")
+            return 1
+
+    delete_credentials()
+    console.print("[ok]Deleted GitHub credentials.[/ok]")
     return 0
 
 

--- a/core/auth/github_pat.py
+++ b/core/auth/github_pat.py
@@ -1,0 +1,130 @@
+"""GitHub personal access token auth module (#102).
+
+Interim credential flow while a real first-class OAuth/device-code GitHub
+connector isn't built yet -- the issue's own Non-Goals explicitly allow this:
+"Do not require GitHub OAuth on day one if a fine-grained PAT bootstrap is
+faster, but make the PAT path productized and resumable." The token is
+collected via a terminal prompt (never chat) and verified against GitHub's
+own API before being stored, mirroring core/auth/anthropic_setup_token.py.
+
+Hexis manages this credential in its own store ONLY. It deliberately never
+reads `gh auth token`, a `GITHUB_TOKEN`/`GITHUB_PERSONAL_ACCESS_TOKEN`
+environment variable, or any other ambient credential -- the issue's other
+explicit Non-Goal ("do not silently consume gh auth ... just because it
+exists").
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+GITHUB_PAT_CONFIG_KEY = "token.github_pat"
+GITHUB_FINE_GRAINED_PAT_PREFIX = "github_pat_"
+GITHUB_CLASSIC_PAT_PREFIX = "ghp_"
+
+
+@dataclass(frozen=True)
+class GithubPatCredentials:
+    token: str
+    login: str | None = None
+
+
+def validate_pat_format(token: str) -> str | None:
+    """Return an error message if the token is obviously malformed, else None."""
+    if not token:
+        return "Token is empty."
+    if not (
+        token.startswith(GITHUB_FINE_GRAINED_PAT_PREFIX)
+        or token.startswith(GITHUB_CLASSIC_PAT_PREFIX)
+    ):
+        return (
+            f"Token must start with '{GITHUB_FINE_GRAINED_PAT_PREFIX}' (fine-grained, "
+            f"preferred) or '{GITHUB_CLASSIC_PAT_PREFIX}' (classic)."
+        )
+    return None
+
+
+async def verify_pat(token: str) -> tuple[str | None, str | None]:
+    """Call GitHub's own API to confirm the token actually works.
+
+    Returns (login, error) -- exactly one is set.
+    """
+    import urllib.error
+    import urllib.request
+
+    request = urllib.request.Request(
+        "https://api.github.com/user",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "Hexis",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        if exc.code == 401:
+            return None, "GitHub rejected the token (401 Unauthorized) — check it wasn't mistyped or revoked."
+        return None, f"GitHub API error: HTTP {exc.code}"
+    except Exception as exc:  # noqa: BLE001 -- network/DNS/timeout, report verbatim
+        return None, f"Could not reach GitHub API: {exc}"
+
+    login = data.get("login") if isinstance(data, dict) else None
+    if not login:
+        return None, "GitHub API response did not include a login — unexpected response shape."
+    return str(login), None
+
+
+def credentials_to_dict(creds: GithubPatCredentials) -> dict[str, Any]:
+    return {"token": creds.token, "login": creds.login}
+
+
+def credentials_from_value(value: Any) -> GithubPatCredentials | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except Exception:
+            return None
+    if not isinstance(value, dict):
+        return None
+    token = value.get("token")
+    if not isinstance(token, str) or not token:
+        return None
+    login = value.get("login")
+    return GithubPatCredentials(token=token, login=login if isinstance(login, str) else None)
+
+
+def load_credentials() -> GithubPatCredentials | None:
+    from core.auth.store import load_auth
+    return credentials_from_value(load_auth(GITHUB_PAT_CONFIG_KEY))
+
+
+def save_credentials(creds: GithubPatCredentials) -> None:
+    from core.auth.store import save_auth
+    save_auth(GITHUB_PAT_CONFIG_KEY, credentials_to_dict(creds))
+
+
+def delete_credentials() -> None:
+    from core.auth.store import delete_auth
+    delete_auth(GITHUB_PAT_CONFIG_KEY)
+
+
+def resolve_github_token() -> tuple[str | None, str]:
+    """Resolve a GitHub token from Hexis's OWN store only.
+
+    Populate the store with:
+        hexis auth github setup-token     # paste a fine-grained or classic PAT
+
+    Returns (token, login): login is the verified GitHub username the token
+    was last confirmed against, or "" if nothing is stored. Never falls back
+    to `gh auth token`, `GITHUB_TOKEN`, or `GITHUB_PERSONAL_ACCESS_TOKEN` from
+    the process environment -- see the module docstring.
+    """
+    creds = load_credentials()
+    if creds:
+        return creds.token, (creds.login or "")
+    return None, ""

--- a/core/tools/skills.py
+++ b/core/tools/skills.py
@@ -39,6 +39,38 @@ _AGENT_SKILL_MANAGER = "author_skill"
 _LEGACY_AGENT_PROVENANCE = "- Authored by Hexis via `author_skill`."
 
 
+def _resolve_stored_mcp_credential(env_var: str) -> str | None:
+    """Bridge an MCP server's required env var to a credential Hexis already
+    manages in its own secret store (#102), instead of requiring the whole
+    service process to carry it. The caller injects the result only into
+    that one server's own subprocess env (MCPServerConfig.env) -- never into
+    os.environ globally, and it is never read from ambient credentials like
+    `gh auth token` (see core/auth/github_pat.py's module docstring)."""
+    if env_var == "GITHUB_PERSONAL_ACCESS_TOKEN":
+        from core.auth.github_pat import resolve_github_token
+
+        token, _login = resolve_github_token()
+        return token
+    return None
+
+
+def _mcp_setup_next_step(missing_env: list[str]) -> str:
+    """A missing-credential next_step that explains itself instead of
+    dead-ending into a bare env-var name (#102)."""
+    if "GITHUB_PERSONAL_ACCESS_TOKEN" in missing_env:
+        return (
+            "GitHub needs a connected account before this can search, create, "
+            "or comment on issues -- a public repo being readable doesn't mean "
+            "acting on it as you is. Run `hexis auth github setup-token` in a "
+            "terminal (never paste the token into chat), then call use_skill "
+            "again."
+        )
+    return (
+        f"Set {', '.join(missing_env)} in the service environment and "
+        "call use_skill again."
+    )
+
+
 class ListSkillsHandler(ToolHandler):
     """List skills available in the current context."""
 
@@ -160,20 +192,35 @@ class UseSkillHandler(ToolHandler):
         from core.tools.config import MCPServerConfig
 
         binding = skill.mcp_binding
-        missing_env = [v for v in binding.env_requires if not os.environ.get(v)]
+        # A required env var absent from the service's own process environment
+        # is not necessarily unresolvable (#102): check whether Hexis already
+        # holds a credential for it in its own secret store first, and inject
+        # that into only this server's own subprocess env (never os.environ
+        # globally) rather than dead-ending into "set X in the service
+        # environment" for something the user already connected.
+        resolved_env: dict[str, str] = {}
+        missing_env: list[str] = []
+        for var in binding.env_requires:
+            if os.environ.get(var):
+                continue
+            stored = _resolve_stored_mcp_credential(var)
+            if stored:
+                resolved_env[var] = stored
+                continue
+            missing_env.append(var)
         if missing_env:
             return {
                 "status": "needs_setup",
                 "missing": [f"missing env var: {v}" for v in missing_env],
-                "next_step": (
-                    f"Set {', '.join(missing_env)} in the service environment and "
-                    "call use_skill again."
-                ),
+                "next_step": _mcp_setup_next_step(missing_env),
             }
 
         if binding.command:
             server_config = MCPServerConfig(
-                name=binding.server, command=binding.command, args=list(binding.args)
+                name=binding.server,
+                command=binding.command,
+                args=list(binding.args),
+                env=resolved_env,
             )
         else:
             config = await context.registry.get_config()

--- a/skills/installed/github-issues/SKILL.md
+++ b/skills/installed/github-issues/SKILL.md
@@ -37,6 +37,10 @@ unlocks the bound tools for this turn.
 
 ## If activation reports needs_setup
 
-Relay the exact `next_step` to the user (usually: set `GITHUB_PERSONAL_ACCESS_TOKEN`
-in the service environment). Do not claim GitHub capability is missing — it is
-installed and one step away.
+Relay the exact `next_step` to the user (#102). It will point them to run
+`hexis auth github setup-token` in a terminal — never ask for or accept a
+token pasted into chat; the tool activation path already checks Hexis's own
+stored credential automatically on retry. Explain, if useful, why a public
+repo still needs this: reading it is public, but creating or commenting on
+an issue as a specific account is not. Do not claim GitHub capability is
+missing — it is installed and one step away.

--- a/tests/cli/test_cli_auth.py
+++ b/tests/cli/test_cli_auth.py
@@ -23,6 +23,7 @@ def test_register_auth_subparsers_creates_providers():
         "openai-codex",
         "anthropic",
         "chutes",
+        "github",
         "github-copilot",
         "qwen-portal",
         "minimax-portal",
@@ -51,8 +52,10 @@ def test_register_auth_subparsers_login_variants():
         args = top.parse_args([provider, "login"])
         assert hasattr(args, "func"), f"{provider} login should set func"
 
-    # Anthropic uses "setup-token" instead of "login"
+    # Anthropic and GitHub use "setup-token" instead of "login"
     args = top.parse_args(["anthropic", "setup-token"])
+    assert hasattr(args, "func")
+    args = top.parse_args(["github", "setup-token"])
     assert hasattr(args, "func")
 
 
@@ -68,7 +71,7 @@ def test_register_auth_subparsers_logout():
     register_auth_subparsers(auth_sub, parent)
 
     for provider in [
-        "openai-codex", "anthropic", "chutes", "github-copilot",
+        "openai-codex", "anthropic", "chutes", "github", "github-copilot",
         "qwen-portal", "minimax-portal", "google-gemini-cli", "google-antigravity",
     ]:
         args = top.parse_args([provider, "logout"])

--- a/tests/core/test_github_pat.py
+++ b/tests/core/test_github_pat.py
@@ -1,0 +1,123 @@
+"""Tests for core/auth/github_pat.py (#102): the interim GitHub credential
+store for the github-issues skill, replacing a dead-end "set an env var"
+message with a productized, verified, terminal-only setup flow.
+"""
+from __future__ import annotations
+
+import pytest
+
+from core.auth.github_pat import (
+    GITHUB_PAT_CONFIG_KEY,
+    GithubPatCredentials,
+    credentials_from_value,
+    credentials_to_dict,
+    delete_credentials,
+    load_credentials,
+    resolve_github_token,
+    save_credentials,
+    validate_pat_format,
+    verify_pat,
+)
+
+pytestmark = [pytest.mark.cli]
+
+
+def test_validate_pat_format_accepts_fine_grained_and_classic():
+    assert validate_pat_format("github_pat_" + "a" * 20) is None
+    assert validate_pat_format("ghp_" + "a" * 20) is None
+
+
+def test_validate_pat_format_rejects_empty_and_wrong_prefix():
+    assert validate_pat_format("") is not None
+    assert "empty" in validate_pat_format("").lower()
+    assert validate_pat_format("sk-not-a-github-token") is not None
+
+
+def test_credentials_round_trip_through_dict():
+    creds = GithubPatCredentials(token="github_pat_abc", login="octocat")
+    restored = credentials_from_value(credentials_to_dict(creds))
+    assert restored == creds
+
+
+def test_credentials_from_value_handles_garbage():
+    assert credentials_from_value(None) is None
+    assert credentials_from_value("not json") is None
+    assert credentials_from_value({"login": "octocat"}) is None  # no token
+    assert credentials_from_value({"token": ""}) is None
+
+
+def test_save_load_delete_round_trip(tmp_path, monkeypatch):
+    import core.auth.store as auth_store
+
+    monkeypatch.setattr(auth_store, "AUTH_DIR", tmp_path / "auth")
+
+    assert load_credentials() is None
+
+    creds = GithubPatCredentials(token="github_pat_" + "z" * 20, login="octocat")
+    save_credentials(creds)
+    loaded = load_credentials()
+    assert loaded == creds
+
+    delete_credentials()
+    assert load_credentials() is None
+
+
+def test_resolve_github_token_never_falls_back_to_ambient_credentials(tmp_path, monkeypatch):
+    """#102 Non-Goal: never silently consume `gh auth token`, `GITHUB_TOKEN`,
+    or any other ambient credential just because it exists."""
+    import core.auth.store as auth_store
+
+    monkeypatch.setattr(auth_store, "AUTH_DIR", tmp_path / "auth")
+    monkeypatch.setenv("GITHUB_TOKEN", "ambient-should-be-ignored")
+    monkeypatch.setenv("GITHUB_PERSONAL_ACCESS_TOKEN", "also-ambient-ignored")
+
+    token, login = resolve_github_token()
+    assert token is None
+    assert login == ""
+
+    save_credentials(GithubPatCredentials(token="github_pat_stored", login="octocat"))
+    token, login = resolve_github_token()
+    assert token == "github_pat_stored"
+    assert login == "octocat"
+
+
+async def test_verify_pat_reports_401_clearly(monkeypatch):
+    import urllib.error
+
+    def fake_urlopen(request, timeout=10):
+        raise urllib.error.HTTPError(request.full_url, 401, "Unauthorized", {}, None)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    login, error = await verify_pat("github_pat_bad")
+    assert login is None
+    assert "401" in error
+
+
+async def test_verify_pat_returns_login_on_success(monkeypatch):
+    import json as _json
+
+    class _FakeResponse:
+        def __init__(self, payload: dict) -> None:
+            self._body = _json.dumps(payload).encode("utf-8")
+
+        def read(self):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def fake_urlopen(request, timeout=10):
+        assert request.get_header("Authorization") == "Bearer github_pat_good"
+        return _FakeResponse({"login": "octocat"})
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    login, error = await verify_pat("github_pat_good")
+    assert error is None
+    assert login == "octocat"
+
+
+def test_config_key_is_namespaced():
+    assert GITHUB_PAT_CONFIG_KEY == "token.github_pat"

--- a/tests/core/test_mcp_lazy_runtime.py
+++ b/tests/core/test_mcp_lazy_runtime.py
@@ -201,3 +201,59 @@ async def test_use_skill_needs_setup_is_not_a_dead_end(
     assert result.output["instructions"]
     # No server started, no tools unlocked.
     assert not any(n.startswith("mcp_") for n in registry.list_names())
+
+
+async def test_use_skill_resolves_stored_github_credential_instead_of_dead_ending(
+    tmp_path, stub_server_config, fresh_singleton, monkeypatch
+):
+    """#102: a required env var missing from the process environment isn't
+    necessarily unresolvable -- Hexis's own stored GitHub credential should
+    be injected into just this server's subprocess env instead of dead-
+    ending into "set X in the service environment"."""
+    monkeypatch.delenv("GITHUB_PERSONAL_ACCESS_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "core.auth.github_pat.resolve_github_token",
+        lambda: ("github_pat_fake123", "octocat"),
+    )
+    script = Path(stub_server_config.args[0])
+    skills_root = _skill_dir_with_manifest(
+        tmp_path, script, env_requires="GITHUB_PERSONAL_ACCESS_TOKEN"
+    )
+    registry = _registry_for_skills(skills_root)
+    context = ToolExecutionContext(
+        tool_context=ToolContext.CHAT, call_id="t3", registry=registry
+    )
+
+    result = await UseSkillHandler().execute({"name": "stub-echo"}, context)
+    assert result.success
+    assert result.output["status"] == "activated"
+    assert "mcp_stub_echo" in result.output["bound_tools"]
+
+    await MCPRuntime.instance().shutdown()
+
+
+async def test_use_skill_github_needs_setup_points_to_setup_token_command(
+    tmp_path, stub_server_config, fresh_singleton, monkeypatch
+):
+    """#102: with nothing stored and no env var, the next_step must explain
+    itself and point at `hexis auth github setup-token` -- never the raw
+    "set GITHUB_PERSONAL_ACCESS_TOKEN in the service environment" dead end,
+    and never a request to paste the token into chat."""
+    monkeypatch.delenv("GITHUB_PERSONAL_ACCESS_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "core.auth.github_pat.resolve_github_token", lambda: (None, "")
+    )
+    script = Path(stub_server_config.args[0])
+    skills_root = _skill_dir_with_manifest(
+        tmp_path, script, env_requires="GITHUB_PERSONAL_ACCESS_TOKEN"
+    )
+    registry = _registry_for_skills(skills_root)
+    context = ToolExecutionContext(
+        tool_context=ToolContext.CHAT, call_id="t4", registry=registry
+    )
+
+    result = await UseSkillHandler().execute({"name": "stub-echo"}, context)
+    assert result.output["status"] == "needs_setup"
+    assert "hexis auth github setup-token" in result.output["next_step"]
+    assert "GITHUB_PERSONAL_ACCESS_TOKEN" not in result.output["next_step"]
+    assert not any(n.startswith("mcp_") for n in registry.list_names())


### PR DESCRIPTION
Addresses #102 (does not close it — see "Not attempted" below; this is a
large multi-surface feature request and this PR deliberately covers only
the acute dead-end).

This issue asks for a first-class GitHub connector: OAuth/device flow, a DB
connector manifest, resumable pending-action state across the auth
interruption, and UI affordances across web/CLI/channels. That's a
multi-day feature effort in its own right. What this PR does is fix the
actual complaint driving the issue — *"asking to file a GitHub issue while
unauthenticated dead-ends into `set GITHUB_PERSONAL_ACCESS_TOKEN in the
service environment`"* — with the interim path the issue's own Non-Goals
explicitly sanction:

> Do not require GitHub OAuth on day one if a fine-grained PAT bootstrap is
> faster, but make the PAT path productized and resumable.

## Why full OAuth isn't reachable here

Checked first: the codebase already has a GitHub device-code flow
(`core/auth/github_copilot.py`), but its OAuth app is registered by GitHub
for Copilot specifically (`scope=read:user`) — not something extensible to
`repo`/`issues` scopes from code. A general-purpose GitHub OAuth app
requires Eric to actually register one with GitHub and configure its client
ID/secret — the same precondition Gmail's hosted OAuth has
(`HEXIS_GMAIL_OAUTH_CLIENT_ID`/`SECRET`) — not something achievable in this
pass.

## What ships

- `core/auth/github_pat.py`: a credential module mirroring
  `anthropic_setup_token.py`'s shape exactly — validate format, verify
  against GitHub's own `/user` API (so a bad paste fails at setup time, not
  activation time), store via the same secret store every other provider
  credential uses. `resolve_github_token()` deliberately reads **only**
  Hexis's own store — never `gh auth token`, `GITHUB_TOKEN`, or
  `GITHUB_PERSONAL_ACCESS_TOKEN` from the ambient environment, per the
  issue's other explicit Non-Goal.
- `hexis auth github setup-token` / `status` / `logout`: a terminal-only
  prompt (`getpass`, never chat) alongside the other `hexis auth <provider>`
  commands, matching that established pattern exactly.
- `core/tools/skills.py`: `MCPServerConfig` already supports a per-server
  `env` dict that overlays the subprocess environment
  (`core/tools/mcp.py` already applies it) — it just wasn't populated for
  skill activation. The missing-env check now falls back to a stored
  credential resolver before declaring a var "missing", and injects it into
  only that MCP server's own subprocess env, never global `os.environ`.
  Extensible: a GitHub-only resolver today, but the seam is generic.
- The `needs_setup` message now explains *why* (public read isn't public
  issue creation) and names the concrete next step
  (`hexis auth github setup-token`) instead of a bare env var name — and the
  skill's own guidance no longer tells the model to relay an env-var
  instruction.

## What's deliberately NOT attempted

First-class OAuth/device flow, a DB-owned `github_issues` connector
manifest in `db/77`, resumable pending-action state (preserving a draft
issue across the auth interruption), and UI affordances for web/CLI/channel
surfaces beyond the terminal prompt this PR adds. All of that remains real,
unaddressed follow-up work — flagging it explicitly rather than claiming
this closes the issue.

## Testing

```
pytest tests/core/test_github_pat.py tests/core/test_mcp_lazy_runtime.py \
       tests/cli/test_cli_auth.py tests/core/test_skill_capability_catalog.py \
       tests/core/test_skills_marketplace.py -q
# 95 passed
ruff check <changed .py files>
# All checks passed!
```

- `tests/core/test_github_pat.py` (new): format validation, credential
  round-trip, garbage-input handling, `verify_pat` against both a 401 and a
  successful response, and the ambient-credential-never-consumed guarantee.
- `tests/core/test_mcp_lazy_runtime.py`: two new tests — a stored GitHub
  credential lets an MCP skill activate without the env var ever being set,
  and with nothing stored the `needs_setup` message names the setup command
  (not the raw env var, not a chat-paste request).
- `tests/cli/test_cli_auth.py`: extended the existing provider-coverage
  tests to include `github` alongside the other providers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub authentication through `hexis auth github`.
  * Users can set up, check, and remove GitHub personal access tokens.
  * GitHub credentials are securely stored and automatically used by supported integrations.
* **Bug Fixes**
  * Improved setup guidance when GitHub credentials are missing.
  * GitHub integrations now clearly report when authentication is required and how to complete setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->