### PR TITLE
Fix get_procedures rejecting calls the DB executor would accept

### DIFF
--- a/core/tools/memory.py
+++ b/core/tools/memory.py
@@ -2132,6 +2132,14 @@ class GetProceduresHandler(ToolHandler):
                         "type": "string",
                         "description": "The task you want to know how to do.",
                     },
+                    "situation": {
+                        "type": "string",
+                        "description": "Alias for task, accepted for compatibility with memory-search wording.",
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Alias for task, accepted for compatibility with memory-search wording.",
+                    },
                     "limit": {
                         "type": "integer",
                         "description": "Maximum procedures to return.",
@@ -2140,7 +2148,7 @@ class GetProceduresHandler(ToolHandler):
                         "maximum": 10,
                     },
                 },
-                "required": ["task"],
+                "required": [],
             },
             category=ToolCategory.MEMORY,
             energy_cost=1,

--- a/tests/core/test_memory_tools.py
+++ b/tests/core/test_memory_tools.py
@@ -18,6 +18,7 @@ import pytest
 from core.tools.base import ToolContext, ToolExecutionContext
 from core.tools.memory import (
     DiffMemoryHistoryHandler,
+    GetProceduresHandler,
     GetStrategiesHandler,
     LoadDocumentsHandler,
     OpenDocumentHandler,
@@ -285,6 +286,16 @@ class TestProvenanceTooling:
         handler = GetStrategiesHandler()
         assert handler.validate({"query": "recover from heartbeat failures"}) == []
         assert handler.validate({"situation": "recover from heartbeat failures"}) == []
+
+    async def test_get_procedures_schema_accepts_situation_and_query_aliases(self):
+        """#109: the DB executor (db/38) already coalesces task/situation/query
+        for get_procedures, same as get_strategies -- the Python schema
+        rejected situation/query calls before they ever reached it."""
+        handler = GetProceduresHandler()
+        assert handler.validate({"task": "deploy the worker"}) == []
+        assert handler.validate({"situation": "deploy the worker"}) == []
+        assert handler.validate({"query": "deploy the worker"}) == []
+        assert handler.spec.parameters["required"] == []
 
     async def test_remember_schema_supports_sources_and_confidence(self):
         spec = RememberHandler().spec


### PR DESCRIPTION
Fixes #109.

## What

Verified live: `GetProceduresHandler`'s schema still had `required: ["task"]`
with no `situation`/`query` alias, while `GetStrategiesHandler` (fixed in
c08c8f5 for the identical class of bug) already accepts `situation`/`query`
with `required: []`.

The asymmetry is the actual bug: the Python validation gate runs **before**
the DB executor and rejects calls the executor would happily serve. `db/38`'s
dispatcher already coalesces `task`/`situation`/`query` identically for both
`get_procedures` and `get_strategies`:

```sql
query := NULLIF(btrim(COALESCE(
    p_args->>'task', p_args->>'situation', p_args->>'query', '')), '');
```

So a model calling `get_procedures` with `situation` or `query` — exactly
the wording it just used successfully for `recall`/`get_strategies` — got
*"Missing required field: task"* instead of the result the database was
already prepared to return.

## Fix

Mirrors `GetStrategiesHandler`'s schema exactly: adds `situation`/`query`
as aliases for `task`, drops the hard `required`, and lets the DB's own
(already permissive) coalescing be the actual contract.

## Testing

```
pytest tests/core/test_memory_tools.py tests/db/test_db_native_tools.py -q
# 27 passed, 4 errors (pre-existing, unrelated -- local embedding sidecar
# not running in this environment)
ruff check core/tools/memory.py tests/core/test_memory_tools.py
# All checks passed!
```

- `test_get_procedures_schema_accepts_situation_and_query_aliases` (new,
  mirrors the existing `get_strategies` alias test): `task`/`situation`/
  `query` all validate cleanly, and `required` is now `[]`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced procedure lookup to accept `task`, `situation`, or `query` when submitting requests.
  * Requests can now omit these fields, providing greater flexibility when searching for procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->