### PR TITLE
Add retention guidance for claims already held after reading a document

### DIFF
--- a/db/40_seed_prompt_modules.sql
+++ b/db/40_seed_prompt_modules.sql
@@ -577,6 +577,8 @@ evidence. Unsupported action claims are detected and corrected publicly.
 
 **Deciding what to retain after reading:** retention is a deliberate act, not a reflex. Retain when the content is salient to your identity, relationships, goals, or strategy; novel (check `sense_memory_availability` first); and from a source you trust. Store salient claims with `remember` — citing `sources` and your `confidence` — or run `slow_ingest` for whole documents that matter; otherwise deliberately let it go. When asked what you retained, answer with memory IDs and provenance, or truthfully "nothing, because...".
 
+**Before concluding "nothing to retain" on a document, check whether its claims are already held.** A foundational document's core claims are often already seeded as memory — checking `sense_memory_availability`/`recall` on *the filename or the fact that you read it* will miss them, because that queries metadata about the reading event, not the substance. Query the actual claims instead (what the document asserts, not that you opened it), and also try `source_kind="origin_document"` — many foundational beliefs carry that provenance and won't surface from a query shaped around ingestion. If you find the claims already held, don't `remember` a duplicate: corroborate with `add_evidence`, or simply cite the existing memory. Concluding "nothing retained" is only honest once you've searched for the claims, not just the file.
+
 The most valuable memories reduce future steering: standing constraints,
 permissions, durable workflow preferences, project decisions, commitments, and
 recurring corrections. Preserve the mechanism that will prevent repeated

--- a/db/migrations/0247_retention_claims_already_held.sql
+++ b/db/migrations/0247_retention_claims_already_held.sql
@@ -1,4 +1,23 @@
-# Conversation System Prompt
+-- Retention guidance misses the "claims already held" case (#51): after
+-- reading a document, "nothing to retain" was concluded even when the
+-- document's core claims already existed as seeded protected origin
+-- memories (source_attribution.kind = 'origin_document', db/60). The
+-- failure mode was query shape, not missing recall discipline: querying
+-- about the FILE ("read philosophy.md") or the reading event finds
+-- nothing, because that's metadata about the act of reading, not the
+-- claims themselves. This adds explicit guidance to services/prompts/
+-- conversation.md's retention-discipline section: query the claims, try
+-- source_kind="origin_document", and corroborate/cite via add_evidence
+-- instead of concluding nothing was retained. Re-upserts the prompt_modules
+-- 'conversation' row so an already-migrated database picks this up too
+-- (nothing reads this DB row at runtime -- the Python loader reads the
+-- file directly -- so this is a pure catalog-sync fix, same class as #115).
+SET search_path = public, ag_catalog, "$user";
+SET check_function_bodies = off;
+
+SELECT upsert_prompt_module(
+    'conversation',
+    $pm$# Conversation System Prompt
 
 You are the initialized agent described by the Active Persona, running on the
 Hexis substrate in live conversation. Hexis provides memory, tools, and
@@ -327,3 +346,7 @@ You have access to someone's memories and tools. That's intimacy.
 - When taught or corrected, remember it.
 - When asked to carry something forward, choose the right durable substrate before replying. Use `manage_schedule` for explicit one-shot timed reminders. Use `manage_responsibility` for ambient responsibilities: "let me know whenever Hope emails me", "watch Slack for anything urgent", "remind me to take pills twice daily", "tell me if I have not checked in", "notify me if my steps are low", or anything that observes a source over time. A promise to watch, remind, or report is a commitment; store it before claiming it is handled.
 - For ambient responsibilities, translate the user's words into trigger/evaluator/source/action fields yourself. Gmail monitors use `sources:[{"connector_id":"gmail","query":"..."}]`; important-only monitors use an importance evaluator; check-ins use `kind:"checkin"` plus a missing-checkin evaluator; wearable/health thresholds use `kind:"threshold"` with the relevant metric. Ask a short clarifying question only if the trigger, source, or action is genuinely missing.
+$pm$,
+    'Seeded from services/prompts/conversation.md',
+    'services/prompts/conversation.md'
+);

--- a/tests/db/test_migrations.py
+++ b/tests/db/test_migrations.py
@@ -91,6 +91,25 @@ async def test_applied_migration_checksum_drift_fails_loudly(db_pool):
             await transaction.rollback()
 
 
+async def test_conversation_prompt_covers_claims_already_held(db_pool):
+    """#51: after reading a document, "nothing to retain" was concluded even
+    when the document's core claims already existed as seeded protected
+    origin memories -- because the failure mode was query shape (searching
+    for the reading event, not the claims). Pins the added guidance and that
+    the DB catalog copy matches the file exactly (migration 0247)."""
+    async with db_pool.acquire() as conn:
+        content = await conn.fetchval(
+            "SELECT content FROM prompt_modules WHERE key = 'conversation'"
+        )
+    assert content is not None
+    assert 'source_kind="origin_document"' in content
+    assert 'Before concluding "nothing to retain"' in content
+    file_content = (
+        _DB_ROOT.parent / "services" / "prompts" / "conversation.md"
+    ).read_text(encoding="utf-8")
+    assert content == file_content
+
+
 async def test_action_receipt_migration_upgrades_existing_memory_dispatch(db_pool):
     """0199 must preserve the old dispatcher while installing remember v2."""
     migration = (


### PR DESCRIPTION
Fixes #51.

## What

Live scenario from the issue: after reading `services/prompts/philosophy.md`,
the agent discussed it richly and concluded "nothing retained" — despite
the document's core claims already existing as seeded protected origin
memories (`source_attribution.kind = 'origin_document'`, `db/60`). Verified
that mechanism is real and unchanged: `db/46i_functions_memory_provenance.sql`
gives `'origin_document'` the highest non-consent default trust (0.90), and
`db/60_origin_memories.sql` is the seed that tags `philosophy.md`'s claims
with it.

The issue's own diagnosis is precise, and it isn't a missing-discipline
problem: `services/prompts/conversation.md` already had *"Deciding what to
retain after reading"* and, separately, *"don't create a duplicate — recall
the belief and use `add_evidence`"* for beliefs generally. The actual
failure was **query shape**: recalling about the FILE ("philosophy.md
document memory created...") or the act of reading it finds nothing,
because that's metadata about the reading event, not the claims
themselves. Neither existing paragraph named this specific trap, or
`source_kind="origin_document"` as somewhere to look.

## Fix

Adds one paragraph to the existing retention-discipline section: before
concluding "nothing to retain," query the actual claims (not the filename
or the reading event), try `source_kind="origin_document"`, and corroborate
via `add_evidence` or cite rather than creating a duplicate.

Propagated to `db/40`'s baseline seed and migration 0247 (re-upserts the
`'conversation'` `prompt_modules` row), matching the pattern already
established for the other stale-prompt-catalog fixes this session (#115,
#108) — nothing reads this DB row at runtime (the Python loader reads the
file directly), so it's a pure catalog-sync fix.

## Testing

```
pytest tests/db/test_migrations.py tests/db/test_relationship_pacing.py -q
# 9 passed
ruff check tests/db/test_migrations.py
# All checks passed!
```

- `test_conversation_prompt_covers_claims_already_held` (new): pins the
  added guidance text and that the DB catalog copy is byte-identical to
  the file.
- No regressions to the many existing substring assertions against the same
  `'conversation'` prompt module (`test_relationship_pacing.py` etc.) — this
  only adds a paragraph, touches nothing existing.
- `hexis migrate` applied cleanly against the running stack; verified live
  that the new guidance and `source_kind="origin_document"` mention are
  present in the `prompt_modules` row.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document retention checks so existing claims are recognized before concluding that nothing should be saved.
  * Existing memories can now be supported with additional evidence or cited instead of being duplicated.

* **Tests**
  * Added coverage to verify the updated retention guidance is consistently stored and applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->