### PR TITLE
Add HMX onboarding interviews: schema, persistence, remember binding, CLI (partial #97)

### DIFF
--- a/apps/cli_exchange.py
+++ b/apps/cli_exchange.py
@@ -20,6 +20,7 @@ from core.hmx_files import (
     serialize_hmx_document,
     write_private_hmx_file,
 )
+from core.hmx_interview import InterviewOutcome, maybe_run_cli_interview
 
 from core.memory_exchange import (
     HmxAnalysisResult,
@@ -393,6 +394,24 @@ def _print_import_result(
             )
 
 
+def _print_interview_outcome(outcome: InterviewOutcome, *, as_json: bool) -> None:
+    if as_json or (not outcome.ran and not outcome.note):
+        return
+
+    from apps.cli_theme import console
+
+    if outcome.note:
+        console.print(f"[muted]{outcome.note}[/muted]")
+        return
+    style = "ok" if outcome.completed and not outcome.failed_bindings else "warn"
+    console.print(
+        f"[{style}]Onboarding interview: {outcome.answered} answered, "
+        f"{outcome.skipped} skipped"
+        + (f", {outcome.failed_bindings} binding(s) not applied" if outcome.failed_bindings else "")
+        + f".[/{style}]"
+    )
+
+
 async def run_export(dsn: str, args: Any) -> int:
     mind_export = bool(getattr(args, "mind", False))
     intent = args.intent
@@ -672,6 +691,9 @@ async def run_import(dsn: str, args: Any) -> int:
         )
         if mind_import:
             continuity = await verify_mind_continuity(conn, document)
+        interview_outcome = await maybe_run_cli_interview(
+            conn, document, interactive=(not args.json and sys.stdin.isatty())
+        )
     finally:
         await conn.close()
 
@@ -681,6 +703,7 @@ async def run_import(dsn: str, args: Any) -> int:
         skipped=skipped,
         continuity=continuity,
     )
+    _print_interview_outcome(interview_outcome, as_json=args.json)
     return 0 if continuity is None or continuity.get("verified") else 2
 
 

--- a/core/hmx_interview.py
+++ b/core/hmx_interview.py
@@ -1,0 +1,150 @@
+"""HMX onboarding interviews (#97): a use case fully defined in one HMX file.
+
+An imported HMX document can carry an ``onboarding_interview`` section
+(schema in ``schemas/hmx-1.7.schema.json``) -- questions the agent asks
+conversationally in the first surface after import, each bound to an action
+via existing machinery. This module runs that interview over the CLI
+(``questionary``, per house ruling that the CLI is line-based); persistence
+and binding execution live in DB functions (``db/49a_hmx_onboarding_interview.sql``)
+so state survives restarts.
+
+Not attempted here (left for follow-up work, called out in the PR): web UI
+button rendering, an init-wizard-stage variant, and binding executors for
+anything other than ``remember`` -- those fail loud with ``not_implemented``
+rather than silently doing nothing.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import asyncpg
+
+from apps.cli_prompts import select_value, text as prompt_text
+
+_SKIP_SENTINEL = object()
+
+
+@dataclass(frozen=True)
+class InterviewOutcome:
+    """What happened running (or not running) an interview."""
+
+    ran: bool
+    completed: bool = False
+    answered: int = 0
+    skipped: int = 0
+    failed_bindings: int = 0
+    note: str | None = None
+
+
+def _coerce_json(value: Any) -> Any:
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
+async def maybe_run_cli_interview(
+    conn: asyncpg.Connection,
+    document: dict[str, Any],
+    *,
+    interactive: bool,
+) -> InterviewOutcome:
+    """Run the document's onboarding_interview, if it has one.
+
+    Returns ``ran=False`` when there is no interview section, or when
+    ``interactive`` is False (e.g. ``--json`` output, or no tty) -- in the
+    latter case the interview state is still started so it can be resumed
+    later, and the caller is told so via ``note``.
+    """
+    interview = document.get("onboarding_interview")
+    if not interview or not interview.get("questions"):
+        return InterviewOutcome(ran=False)
+
+    export_id = document["export_id"]
+    state = _coerce_json(
+        await conn.fetchval(
+            "SELECT start_hmx_interview($1, $2::jsonb)",
+            export_id,
+            _dumps(interview),
+        )
+    )
+
+    if not interactive:
+        return InterviewOutcome(
+            ran=False,
+            note=(
+                f"This import includes an onboarding interview ({len(interview['questions'])} "
+                "question(s)) that was not run (non-interactive session). Its state was "
+                f"recorded under export_id {export_id}."
+            ),
+        )
+
+    if state["status"] == "completed":
+        return InterviewOutcome(ran=False, note="This import's onboarding interview was already completed.")
+
+    answered_ids = {a["question_id"] for a in state["answers"] if a["status"] in ("answered", "skipped")}
+    answered = skipped = failed_bindings = 0
+
+    print()
+    print("This use case has a few questions for you.")
+    for question in interview["questions"]:
+        if question["id"] in answered_ids:
+            continue
+        outcome = await _ask_one(question)
+        if outcome is _SKIP_SENTINEL:
+            await conn.fetchval(
+                "SELECT record_hmx_interview_answer($1, $2, 'skipped')",
+                export_id,
+                question["id"],
+            )
+            skipped += 1
+            continue
+        result = _coerce_json(
+            await conn.fetchval(
+                "SELECT record_hmx_interview_answer($1, $2, 'answered', $3::jsonb)",
+                export_id,
+                question["id"],
+                _dumps(outcome),
+            )
+        )
+        answered += 1
+        binding = result.get("binding_result") or {}
+        if not binding.get("success", True):
+            failed_bindings += 1
+            print(f"  (could not apply: {binding.get('error', 'unknown error')})")
+
+    final_state = _coerce_json(await conn.fetchval("SELECT get_hmx_interview_state($1)", export_id))
+    return InterviewOutcome(
+        ran=True,
+        completed=final_state["status"] == "completed",
+        answered=answered,
+        skipped=skipped,
+        failed_bindings=failed_bindings,
+    )
+
+
+async def _ask_one(question: dict[str, Any]) -> Any:
+    """Ask one question; returns the answer value, or _SKIP_SENTINEL."""
+    skippable = bool(question.get("skippable", not question.get("required", False)))
+    prompt = question["prompt"]
+
+    if question["type"] == "choice":
+        pairs = [(opt["label"], opt["value"]) for opt in question.get("options", [])]
+        if skippable:
+            pairs = [*pairs, ("(skip this question)", _SKIP_SENTINEL)]
+        return await select_value(prompt, pairs)
+
+    # freeform
+    while True:
+        answer = await prompt_text(prompt)
+        answer = (answer or "").strip()
+        if answer:
+            return answer
+        if skippable:
+            return _SKIP_SENTINEL
+        print("  This one needs an answer.")
+
+
+def _dumps(value: Any) -> str:
+    return json.dumps(value)

--- a/db/49a_hmx_onboarding_interview.sql
+++ b/db/49a_hmx_onboarding_interview.sql
@@ -1,0 +1,194 @@
+-- #97: HMX onboarding interviews -- a use case fully defined in one HMX
+-- file. An import can carry an `onboarding_interview` section (schema in
+-- schemas/hmx-1.7.schema.json); this table persists per-import interview
+-- progress (keyed by the document's own export_id) so it survives restarts
+-- and can be resumed, and each answer's binding execution is recorded for
+-- provenance/audit. Binding execution itself lives in
+-- apply_hmx_interview_binding() below -- currently 'remember' is wired to
+-- real memory creation; the other documented binding actions (ingest,
+-- init_identity, create_goal, set_guardrail, create_scheduled_task,
+-- set_config) fail loud with 'not_implemented' rather than silently no-op.
+SET search_path = public, ag_catalog, "$user";
+
+CREATE TABLE IF NOT EXISTS hmx_interview_state (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    export_id TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'completed')),
+    interview_version INT NOT NULL,
+    questions JSONB NOT NULL,
+    answers JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_hmx_interview_state_status
+    ON hmx_interview_state (status);
+
+-- Starts (or, idempotently, returns) the persisted interview for one import.
+-- p_interview is the envelope's whole onboarding_interview object.
+CREATE OR REPLACE FUNCTION start_hmx_interview(
+    p_export_id TEXT,
+    p_interview JSONB
+) RETURNS JSONB AS $$
+DECLARE
+    existing hmx_interview_state%ROWTYPE;
+BEGIN
+    SELECT * INTO existing FROM hmx_interview_state WHERE export_id = p_export_id;
+    IF FOUND THEN
+        RETURN to_jsonb(existing);
+    END IF;
+
+    INSERT INTO hmx_interview_state (export_id, interview_version, questions)
+    VALUES (
+        p_export_id,
+        COALESCE((p_interview->>'version')::int, 1),
+        COALESCE(p_interview->'questions', '[]'::jsonb)
+    )
+    RETURNING * INTO existing;
+    RETURN to_jsonb(existing);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION get_hmx_interview_state(p_export_id TEXT)
+RETURNS JSONB AS $$
+    SELECT to_jsonb(s) FROM hmx_interview_state s WHERE export_id = p_export_id;
+$$ LANGUAGE sql STABLE;
+
+-- Simple `{{answer}}` token substitution into a binding's params_template.
+-- Deliberately minimal (no conditionals/loops): the HMX standard's contract
+-- here is "one answer fills one template", not a general templating engine.
+CREATE OR REPLACE FUNCTION _hmx_interview_fill_template(
+    p_template JSONB,
+    p_answer_text TEXT
+) RETURNS JSONB AS $$
+    SELECT CASE jsonb_typeof(p_template)
+        WHEN 'string' THEN to_jsonb(replace(p_template #>> '{}', '{{answer}}', COALESCE(p_answer_text, '')))
+        WHEN 'object' THEN COALESCE((
+            SELECT jsonb_object_agg(key, _hmx_interview_fill_template(value, p_answer_text))
+            FROM jsonb_each(p_template)
+        ), '{}'::jsonb)
+        WHEN 'array' THEN COALESCE((
+            SELECT jsonb_agg(_hmx_interview_fill_template(value, p_answer_text))
+            FROM jsonb_array_elements(p_template)
+        ), '[]'::jsonb)
+        ELSE p_template
+    END;
+$$ LANGUAGE sql IMMUTABLE;
+
+-- Executes one question's binding against its recorded answer. Returns the
+-- executed tool/action result, always with a 'success' key -- an
+-- unimplemented action is a loud, structured failure, never a silent no-op.
+CREATE OR REPLACE FUNCTION apply_hmx_interview_binding(
+    p_action TEXT,
+    p_params_template JSONB,
+    p_answer JSONB,
+    p_export_id TEXT,
+    p_question_id TEXT
+) RETURNS JSONB AS $$
+DECLARE
+    answer_text TEXT := CASE jsonb_typeof(p_answer)
+        WHEN 'string' THEN p_answer #>> '{}'
+        ELSE p_answer::text
+    END;
+    filled JSONB := _hmx_interview_fill_template(COALESCE(p_params_template, '{}'::jsonb), answer_text);
+BEGIN
+    IF p_action = 'remember' THEN
+        -- Provenance always carries the interview's own identity, regardless
+        -- of what the HMX author's params_template did or didn't set.
+        filled := filled || jsonb_build_object(
+            'sources', COALESCE(filled->'sources', '[]'::jsonb) || jsonb_build_array(
+                jsonb_build_object('kind', 'hmx_interview', 'ref', p_export_id, 'label', p_question_id)
+            )
+        );
+        RETURN execute_memory_tool('remember', filled);
+    END IF;
+    RETURN jsonb_build_object(
+        'success', false,
+        'error', format('HMX onboarding-interview binding action %L is not yet implemented', p_action),
+        'error_type', 'not_implemented'
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+-- Records one question's answer (or skip), applies its binding when
+-- answered, and advances/completes the interview. p_status is 'answered' or
+-- 'skipped'; skips never execute a binding.
+CREATE OR REPLACE FUNCTION record_hmx_interview_answer(
+    p_export_id TEXT,
+    p_question_id TEXT,
+    p_status TEXT,
+    p_answer JSONB DEFAULT NULL
+) RETURNS JSONB AS $$
+DECLARE
+    state hmx_interview_state%ROWTYPE;
+    question JSONB;
+    binding_result JSONB;
+    entry JSONB;
+    updated_answers JSONB;
+    all_required_settled BOOLEAN;
+BEGIN
+    IF p_status NOT IN ('answered', 'skipped') THEN
+        RAISE EXCEPTION 'invalid interview answer status: %', p_status;
+    END IF;
+
+    SELECT * INTO state FROM hmx_interview_state WHERE export_id = p_export_id FOR UPDATE;
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object('success', false, 'error', 'no interview in progress for this export_id');
+    END IF;
+
+    SELECT value INTO question
+    FROM jsonb_array_elements(state.questions) value
+    WHERE value->>'id' = p_question_id;
+    IF question IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', format('unknown question id: %s', p_question_id));
+    END IF;
+
+    IF p_status = 'answered' THEN
+        binding_result := apply_hmx_interview_binding(
+            question->'binds'->>'action', question->'binds'->'params_template',
+            p_answer, p_export_id, p_question_id
+        );
+    END IF;
+
+    entry := jsonb_build_object(
+        'question_id', p_question_id,
+        'status', p_status,
+        'answer', p_answer,
+        'binding_result', binding_result,
+        'answered_at', CURRENT_TIMESTAMP
+    );
+    -- Idempotent-ish: replace any prior entry for this question rather than
+    -- accumulating duplicates if a caller retries.
+    UPDATE hmx_interview_state
+    SET answers = (
+            SELECT COALESCE(jsonb_agg(a), '[]'::jsonb)
+            FROM jsonb_array_elements(answers) a
+            WHERE a->>'question_id' != p_question_id
+        ) || jsonb_build_array(entry),
+        updated_at = CURRENT_TIMESTAMP
+    WHERE export_id = p_export_id
+    RETURNING answers INTO updated_answers;
+
+    SELECT NOT EXISTS (
+        SELECT 1 FROM jsonb_array_elements(state.questions) q
+        WHERE COALESCE((q->>'required')::boolean, FALSE)
+          AND NOT EXISTS (
+              SELECT 1 FROM jsonb_array_elements(updated_answers) a
+              WHERE a->>'question_id' = q->>'id' AND a->>'status' = 'answered'
+          )
+    ) INTO all_required_settled;
+
+    IF all_required_settled THEN
+        UPDATE hmx_interview_state SET status = 'completed', updated_at = CURRENT_TIMESTAMP
+        WHERE export_id = p_export_id;
+    END IF;
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'question_id', p_question_id,
+        'status', p_status,
+        'binding_result', binding_result,
+        'interview_status', CASE WHEN all_required_settled THEN 'completed' ELSE 'pending' END
+    );
+END;
+$$ LANGUAGE plpgsql;

--- a/db/migrations/0250_hmx_onboarding_interview.sql
+++ b/db/migrations/0250_hmx_onboarding_interview.sql
@@ -1,0 +1,194 @@
+-- #97: HMX onboarding interviews -- a use case fully defined in one HMX
+-- file. An import can carry an `onboarding_interview` section (schema in
+-- schemas/hmx-1.7.schema.json); this table persists per-import interview
+-- progress (keyed by the document's own export_id) so it survives restarts
+-- and can be resumed, and each answer's binding execution is recorded for
+-- provenance/audit. Binding execution itself lives in
+-- apply_hmx_interview_binding() below -- currently 'remember' is wired to
+-- real memory creation; the other documented binding actions (ingest,
+-- init_identity, create_goal, set_guardrail, create_scheduled_task,
+-- set_config) fail loud with 'not_implemented' rather than silently no-op.
+SET search_path = public, ag_catalog, "$user";
+
+CREATE TABLE IF NOT EXISTS hmx_interview_state (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    export_id TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'completed')),
+    interview_version INT NOT NULL,
+    questions JSONB NOT NULL,
+    answers JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_hmx_interview_state_status
+    ON hmx_interview_state (status);
+
+-- Starts (or, idempotently, returns) the persisted interview for one import.
+-- p_interview is the envelope's whole onboarding_interview object.
+CREATE OR REPLACE FUNCTION start_hmx_interview(
+    p_export_id TEXT,
+    p_interview JSONB
+) RETURNS JSONB AS $$
+DECLARE
+    existing hmx_interview_state%ROWTYPE;
+BEGIN
+    SELECT * INTO existing FROM hmx_interview_state WHERE export_id = p_export_id;
+    IF FOUND THEN
+        RETURN to_jsonb(existing);
+    END IF;
+
+    INSERT INTO hmx_interview_state (export_id, interview_version, questions)
+    VALUES (
+        p_export_id,
+        COALESCE((p_interview->>'version')::int, 1),
+        COALESCE(p_interview->'questions', '[]'::jsonb)
+    )
+    RETURNING * INTO existing;
+    RETURN to_jsonb(existing);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION get_hmx_interview_state(p_export_id TEXT)
+RETURNS JSONB AS $$
+    SELECT to_jsonb(s) FROM hmx_interview_state s WHERE export_id = p_export_id;
+$$ LANGUAGE sql STABLE;
+
+-- Simple `{{answer}}` token substitution into a binding's params_template.
+-- Deliberately minimal (no conditionals/loops): the HMX standard's contract
+-- here is "one answer fills one template", not a general templating engine.
+CREATE OR REPLACE FUNCTION _hmx_interview_fill_template(
+    p_template JSONB,
+    p_answer_text TEXT
+) RETURNS JSONB AS $$
+    SELECT CASE jsonb_typeof(p_template)
+        WHEN 'string' THEN to_jsonb(replace(p_template #>> '{}', '{{answer}}', COALESCE(p_answer_text, '')))
+        WHEN 'object' THEN COALESCE((
+            SELECT jsonb_object_agg(key, _hmx_interview_fill_template(value, p_answer_text))
+            FROM jsonb_each(p_template)
+        ), '{}'::jsonb)
+        WHEN 'array' THEN COALESCE((
+            SELECT jsonb_agg(_hmx_interview_fill_template(value, p_answer_text))
+            FROM jsonb_array_elements(p_template)
+        ), '[]'::jsonb)
+        ELSE p_template
+    END;
+$$ LANGUAGE sql IMMUTABLE;
+
+-- Executes one question's binding against its recorded answer. Returns the
+-- executed tool/action result, always with a 'success' key -- an
+-- unimplemented action is a loud, structured failure, never a silent no-op.
+CREATE OR REPLACE FUNCTION apply_hmx_interview_binding(
+    p_action TEXT,
+    p_params_template JSONB,
+    p_answer JSONB,
+    p_export_id TEXT,
+    p_question_id TEXT
+) RETURNS JSONB AS $$
+DECLARE
+    answer_text TEXT := CASE jsonb_typeof(p_answer)
+        WHEN 'string' THEN p_answer #>> '{}'
+        ELSE p_answer::text
+    END;
+    filled JSONB := _hmx_interview_fill_template(COALESCE(p_params_template, '{}'::jsonb), answer_text);
+BEGIN
+    IF p_action = 'remember' THEN
+        -- Provenance always carries the interview's own identity, regardless
+        -- of what the HMX author's params_template did or didn't set.
+        filled := filled || jsonb_build_object(
+            'sources', COALESCE(filled->'sources', '[]'::jsonb) || jsonb_build_array(
+                jsonb_build_object('kind', 'hmx_interview', 'ref', p_export_id, 'label', p_question_id)
+            )
+        );
+        RETURN execute_memory_tool('remember', filled);
+    END IF;
+    RETURN jsonb_build_object(
+        'success', false,
+        'error', format('HMX onboarding-interview binding action %L is not yet implemented', p_action),
+        'error_type', 'not_implemented'
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+-- Records one question's answer (or skip), applies its binding when
+-- answered, and advances/completes the interview. p_status is 'answered' or
+-- 'skipped'; skips never execute a binding.
+CREATE OR REPLACE FUNCTION record_hmx_interview_answer(
+    p_export_id TEXT,
+    p_question_id TEXT,
+    p_status TEXT,
+    p_answer JSONB DEFAULT NULL
+) RETURNS JSONB AS $$
+DECLARE
+    state hmx_interview_state%ROWTYPE;
+    question JSONB;
+    binding_result JSONB;
+    entry JSONB;
+    updated_answers JSONB;
+    all_required_settled BOOLEAN;
+BEGIN
+    IF p_status NOT IN ('answered', 'skipped') THEN
+        RAISE EXCEPTION 'invalid interview answer status: %', p_status;
+    END IF;
+
+    SELECT * INTO state FROM hmx_interview_state WHERE export_id = p_export_id FOR UPDATE;
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object('success', false, 'error', 'no interview in progress for this export_id');
+    END IF;
+
+    SELECT value INTO question
+    FROM jsonb_array_elements(state.questions) value
+    WHERE value->>'id' = p_question_id;
+    IF question IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', format('unknown question id: %s', p_question_id));
+    END IF;
+
+    IF p_status = 'answered' THEN
+        binding_result := apply_hmx_interview_binding(
+            question->'binds'->>'action', question->'binds'->'params_template',
+            p_answer, p_export_id, p_question_id
+        );
+    END IF;
+
+    entry := jsonb_build_object(
+        'question_id', p_question_id,
+        'status', p_status,
+        'answer', p_answer,
+        'binding_result', binding_result,
+        'answered_at', CURRENT_TIMESTAMP
+    );
+    -- Idempotent-ish: replace any prior entry for this question rather than
+    -- accumulating duplicates if a caller retries.
+    UPDATE hmx_interview_state
+    SET answers = (
+            SELECT COALESCE(jsonb_agg(a), '[]'::jsonb)
+            FROM jsonb_array_elements(answers) a
+            WHERE a->>'question_id' != p_question_id
+        ) || jsonb_build_array(entry),
+        updated_at = CURRENT_TIMESTAMP
+    WHERE export_id = p_export_id
+    RETURNING answers INTO updated_answers;
+
+    SELECT NOT EXISTS (
+        SELECT 1 FROM jsonb_array_elements(state.questions) q
+        WHERE COALESCE((q->>'required')::boolean, FALSE)
+          AND NOT EXISTS (
+              SELECT 1 FROM jsonb_array_elements(updated_answers) a
+              WHERE a->>'question_id' = q->>'id' AND a->>'status' = 'answered'
+          )
+    ) INTO all_required_settled;
+
+    IF all_required_settled THEN
+        UPDATE hmx_interview_state SET status = 'completed', updated_at = CURRENT_TIMESTAMP
+        WHERE export_id = p_export_id;
+    END IF;
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'question_id', p_question_id,
+        'status', p_status,
+        'binding_result', binding_result,
+        'interview_status', CASE WHEN all_required_settled THEN 'completed' ELSE 'pending' END
+    );
+END;
+$$ LANGUAGE plpgsql;

--- a/schemas/hmx-1.7.schema.json
+++ b/schemas/hmx-1.7.schema.json
@@ -21,7 +21,8 @@
       "additionalProperties": {"$ref": "#/$defs/sha256"}
     },
     "statistics": {"$ref": "#/$defs/statistics"},
-    "export_warnings": {"type": "array", "items": {"type": "string"}}
+    "export_warnings": {"type": "array", "items": {"type": "string"}},
+    "onboarding_interview": {"$ref": "#/$defs/onboardingInterview"}
   },
   "additionalProperties": true,
   "$defs": {
@@ -553,6 +554,65 @@
         "estimated_embedding_tokens": {"type": "integer", "minimum": 0},
         "estimated_embedding_cost_units": {"type": ["number", "null"]},
         "estimated_uncompressed_bytes": {"type": "integer", "minimum": 0}
+      },
+      "additionalProperties": true
+    },
+    "onboardingInterviewOption": {
+      "type": "object",
+      "required": ["label", "value"],
+      "properties": {
+        "label": {"type": "string"},
+        "value": {}
+      },
+      "additionalProperties": true
+    },
+    "onboardingInterviewBinding": {
+      "type": "object",
+      "required": ["action"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "remember",
+            "ingest",
+            "init_identity",
+            "create_goal",
+            "set_guardrail",
+            "create_scheduled_task",
+            "set_config"
+          ]
+        },
+        "params_template": {"type": "object"}
+      },
+      "additionalProperties": true
+    },
+    "onboardingInterviewQuestion": {
+      "type": "object",
+      "required": ["id", "type", "prompt", "binds"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "type": {"type": "string", "enum": ["choice", "freeform"]},
+        "prompt": {"type": "string", "minLength": 1},
+        "options": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/onboardingInterviewOption"}
+        },
+        "binds": {"$ref": "#/$defs/onboardingInterviewBinding"},
+        "required": {"type": "boolean"},
+        "skippable": {"type": "boolean"}
+      },
+      "additionalProperties": true
+    },
+    "onboardingInterview": {
+      "type": "object",
+      "description": "A use case fully defined in one HMX file (#97): questions the agent asks conversationally in the first chat after import, each bound to an action via existing machinery (remember, ingestion, identity, goals, guardrails, scheduled tasks, config).",
+      "required": ["version", "questions"],
+      "properties": {
+        "version": {"type": "integer", "minimum": 1},
+        "questions": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/onboardingInterviewQuestion"}
+        }
       },
       "additionalProperties": true
     }

--- a/tests/core/test_hmx_exchange.py
+++ b/tests/core/test_hmx_exchange.py
@@ -263,6 +263,85 @@ class TestCanonicalSchema:
         validate_hmx_document(env)
 
 
+class TestOnboardingInterviewSchema:
+    """#97: a use case fully defined in one HMX file -- the envelope's
+    optional onboarding_interview section, part of the open HMX standard."""
+
+    def _envelope(self):
+        plan = resolve_export_sections("port")
+        return build_envelope(
+            intent="port",
+            plan=plan,
+            instance_id="hexis_test",
+            schema_version="0004_hmx_export_functions",
+            embedding_model="embeddinggemma:300m",
+            embedding_dimension=768,
+            lineage_id="11111111-2222-3333-4444-555555555555",
+            relationship_edge_types=["SUPPORTS"],
+        )
+
+    def _question(self, **overrides):
+        question = {
+            "id": "q1",
+            "type": "choice",
+            "prompt": "What should I call you?",
+            "options": [
+                {"label": "Boss", "value": "boss"},
+                {"label": "Friend", "value": "friend"},
+            ],
+            "binds": {"action": "remember", "params_template": {"content": "{{answer}}"}},
+        }
+        question.update(overrides)
+        return question
+
+    def test_well_formed_interview_is_valid(self):
+        env = self._envelope()
+        env["onboarding_interview"] = {"version": 1, "questions": [self._question()]}
+        validate_hmx_document(env)
+
+    def test_freeform_question_without_options_is_valid(self):
+        env = self._envelope()
+        # A freeform question legitimately omits 'options' entirely.
+        question = self._question(id="q2", type="freeform", prompt="Anything else I should know?")
+        del question["options"]
+        env["onboarding_interview"] = {"version": 1, "questions": [question]}
+        validate_hmx_document(env)
+
+    def test_required_and_skippable_flags_are_valid(self):
+        env = self._envelope()
+        env["onboarding_interview"] = {
+            "version": 1,
+            "questions": [self._question(required=True, skippable=False)],
+        }
+        validate_hmx_document(env)
+
+    def test_missing_binds_is_rejected(self):
+        env = self._envelope()
+        question = self._question()
+        del question["binds"]
+        env["onboarding_interview"] = {"version": 1, "questions": [question]}
+        with pytest.raises(HmxSchemaError, match="'binds' is a required property"):
+            validate_hmx_document(env)
+
+    def test_unknown_binding_action_is_rejected(self):
+        env = self._envelope()
+        question = self._question(binds={"action": "launch_missiles"})
+        env["onboarding_interview"] = {"version": 1, "questions": [question]}
+        with pytest.raises(HmxSchemaError):
+            validate_hmx_document(env)
+
+    def test_option_missing_value_is_rejected(self):
+        env = self._envelope()
+        question = self._question(options=[{"label": "Boss"}])
+        env["onboarding_interview"] = {"version": 1, "questions": [question]}
+        with pytest.raises(HmxSchemaError, match="'value' is a required property"):
+            validate_hmx_document(env)
+
+    def test_document_without_interview_section_still_validates(self):
+        # The section is optional -- every existing HMX document stays valid.
+        validate_hmx_document(self._envelope())
+
+
 class TestJsonlTransport:
     def _envelope(self):
         plan = resolve_export_sections(

--- a/tests/core/test_hmx_interview.py
+++ b/tests/core/test_hmx_interview.py
@@ -1,0 +1,235 @@
+"""core/hmx_interview.py: the CLI-facing orchestration for HMX onboarding
+interviews (#97). The DB does persistence + binding execution
+(tests/db/test_hmx_onboarding_interview.py); this covers the question-loop
+logic -- skip handling, the required-question re-ask loop, and the
+non-interactive/no-section/already-completed short-circuits -- against a
+mocked connection and mocked prompts.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.hmx_interview import maybe_run_cli_interview
+
+pytestmark = pytest.mark.asyncio
+
+
+def _document(**interview_overrides):
+    interview = {
+        "version": 1,
+        "questions": [
+            {
+                "id": "name",
+                "type": "choice",
+                "prompt": "What should I call you?",
+                "options": [{"label": "Boss", "value": "boss"}, {"label": "Friend", "value": "friend"}],
+                "binds": {"action": "remember", "params_template": {}},
+                "skippable": True,
+            },
+            {
+                "id": "extra",
+                "type": "freeform",
+                "prompt": "Anything else?",
+                "binds": {"action": "remember", "params_template": {}},
+                "skippable": True,
+            },
+        ],
+    }
+    interview.update(interview_overrides)
+    return {"export_id": "exp_1111111111111111", "onboarding_interview": interview}
+
+
+def _mock_conn(*, state_after_start, per_question_results):
+    """conn.fetchval dispatches on the SQL text's first word after SELECT."""
+
+    async def fetchval(query, *args):
+        if "start_hmx_interview" in query:
+            return json.dumps(state_after_start)
+        if "record_hmx_interview_answer" in query:
+            question_id = args[1]
+            return json.dumps(per_question_results[question_id])
+        if "get_hmx_interview_state" in query:
+            return json.dumps(state_after_start | {"status": "completed"})
+        raise AssertionError(f"unexpected query: {query}")
+
+    conn = AsyncMock()
+    conn.fetchval.side_effect = fetchval
+    return conn
+
+
+async def test_no_interview_section_is_a_no_op():
+    conn = AsyncMock()
+    outcome = await maybe_run_cli_interview(conn, {"export_id": "exp_x"}, interactive=True)
+    assert outcome.ran is False
+    conn.fetchval.assert_not_called()
+
+
+async def test_non_interactive_starts_but_does_not_prompt():
+    conn = _mock_conn(
+        state_after_start={"status": "pending", "answers": []},
+        per_question_results={},
+    )
+    doc = _document()
+    with patch("core.hmx_interview.select_value") as select_mock:
+        outcome = await maybe_run_cli_interview(conn, doc, interactive=False)
+    assert outcome.ran is False
+    assert doc["export_id"] in outcome.note
+    select_mock.assert_not_called()
+    conn.fetchval.assert_called_once()  # only start_hmx_interview
+
+
+async def test_already_completed_interview_is_skipped():
+    conn = _mock_conn(
+        state_after_start={"status": "completed", "answers": []},
+        per_question_results={},
+    )
+    with patch("core.hmx_interview.select_value") as select_mock:
+        outcome = await maybe_run_cli_interview(conn, _document(), interactive=True)
+    assert outcome.ran is False
+    assert "already completed" in outcome.note
+    select_mock.assert_not_called()
+
+
+async def test_choice_and_freeform_questions_answered_end_to_end():
+    conn = _mock_conn(
+        state_after_start={"status": "pending", "answers": []},
+        per_question_results={
+            "name": {
+                "success": True,
+                "binding_result": {"success": True},
+                "interview_status": "pending",
+            },
+            "extra": {
+                "success": True,
+                "binding_result": {"success": True},
+                "interview_status": "completed",
+            },
+        },
+    )
+    with (
+        patch("core.hmx_interview.select_value", new=AsyncMock(return_value="friend")),
+        patch("core.hmx_interview.prompt_text", new=AsyncMock(return_value="nothing else")),
+    ):
+        outcome = await maybe_run_cli_interview(conn, _document(), interactive=True)
+
+    assert outcome.ran is True
+    assert outcome.completed is True
+    assert outcome.answered == 2
+    assert outcome.skipped == 0
+    assert outcome.failed_bindings == 0
+
+    # The choice answer's value (not its label) is what gets recorded.
+    answer_calls = [c for c in conn.fetchval.call_args_list if "record_hmx_interview_answer" in c.args[0]]
+    assert len(answer_calls) == 2
+    assert json.loads(answer_calls[0].args[3]) == "friend"
+    assert json.loads(answer_calls[1].args[3]) == "nothing else"
+
+
+async def test_skippable_freeform_question_skips_on_empty_answer():
+    conn = _mock_conn(
+        state_after_start={"status": "pending", "answers": []},
+        per_question_results={
+            "name": {"success": True, "binding_result": None, "interview_status": "pending"},
+        },
+    )
+    doc = _document(
+        questions=[
+            {
+                "id": "name",
+                "type": "freeform",
+                "prompt": "What should I call you?",
+                "binds": {"action": "remember", "params_template": {}},
+                "skippable": True,
+            }
+        ]
+    )
+    with patch("core.hmx_interview.prompt_text", new=AsyncMock(return_value="")):
+        outcome = await maybe_run_cli_interview(conn, doc, interactive=True)
+
+    assert outcome.skipped == 1
+    assert outcome.answered == 0
+    skip_calls = [c for c in conn.fetchval.call_args_list if "record_hmx_interview_answer" in c.args[0]]
+    assert len(skip_calls) == 1
+    assert "'skipped'" in skip_calls[0].args[0]
+    assert skip_calls[0].args[2] == "name"
+
+
+async def test_required_freeform_question_re_asks_until_answered():
+    conn = _mock_conn(
+        state_after_start={"status": "pending", "answers": []},
+        per_question_results={
+            "name": {"success": True, "binding_result": {"success": True}, "interview_status": "completed"},
+        },
+    )
+    doc = _document(
+        questions=[
+            {
+                "id": "name",
+                "type": "freeform",
+                "prompt": "What should I call you?",
+                "binds": {"action": "remember", "params_template": {}},
+                "required": True,
+                "skippable": False,
+            }
+        ]
+    )
+    prompt_mock = AsyncMock(side_effect=["", "  ", "Friend"])
+    with patch("core.hmx_interview.prompt_text", new=prompt_mock):
+        outcome = await maybe_run_cli_interview(conn, doc, interactive=True)
+
+    assert prompt_mock.await_count == 3
+    assert outcome.answered == 1
+    assert outcome.skipped == 0
+
+
+async def test_failed_binding_is_counted_and_reported():
+    conn = _mock_conn(
+        state_after_start={"status": "pending", "answers": []},
+        per_question_results={
+            "name": {
+                "success": True,
+                "binding_result": {"success": False, "error": "nope", "error_type": "not_implemented"},
+                "interview_status": "completed",
+            },
+        },
+    )
+    doc = _document(
+        questions=[
+            {
+                "id": "name",
+                "type": "choice",
+                "prompt": "Pick one",
+                "options": [{"label": "A", "value": "a"}],
+                "binds": {"action": "create_goal", "params_template": {}},
+                "skippable": True,
+            }
+        ]
+    )
+    with patch("core.hmx_interview.select_value", new=AsyncMock(return_value="a")):
+        outcome = await maybe_run_cli_interview(conn, doc, interactive=True)
+
+    assert outcome.answered == 1
+    assert outcome.failed_bindings == 1
+
+
+async def test_already_answered_questions_are_not_re_asked():
+    conn = _mock_conn(
+        state_after_start={
+            "status": "pending",
+            "answers": [{"question_id": "name", "status": "answered"}],
+        },
+        per_question_results={
+            "extra": {"success": True, "binding_result": {"success": True}, "interview_status": "completed"},
+        },
+    )
+    with (
+        patch("core.hmx_interview.select_value", new=AsyncMock()) as select_mock,
+        patch("core.hmx_interview.prompt_text", new=AsyncMock(return_value="ok")),
+    ):
+        outcome = await maybe_run_cli_interview(conn, _document(), interactive=True)
+
+    select_mock.assert_not_called()  # 'name' (choice) already answered
+    assert outcome.answered == 1  # only 'extra' asked

--- a/tests/db/test_hmx_onboarding_interview.py
+++ b/tests/db/test_hmx_onboarding_interview.py
@@ -1,0 +1,265 @@
+"""HMX onboarding interviews (#97): the persistence + binding-execution layer
+in db/49a_hmx_onboarding_interview.sql. A use case fully defined in one HMX
+file can carry a set of questions that bind answers to actions via existing
+machinery -- these tests cover the state machine (start/answer/skip/resume/
+completion) and the 'remember' binding executor end to end, plus an
+unimplemented binding failing loud rather than silently doing nothing.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.utils import get_test_identifier
+
+pytestmark = [pytest.mark.asyncio(loop_scope="session")]
+
+
+def _j(value):
+    return json.loads(value) if isinstance(value, str) else value
+
+
+def _interview(marker: str, **overrides) -> dict:
+    spec = {
+        "version": 1,
+        "questions": [
+            {
+                "id": "name",
+                "type": "choice",
+                "prompt": "What should I call you?",
+                "options": [
+                    {"label": "Boss", "value": "boss"},
+                    {"label": "Friend", "value": "friend"},
+                ],
+                "binds": {
+                    "action": "remember",
+                    "params_template": {
+                        "content": f"The user {marker} wants to be called {{{{answer}}}}",
+                        "type": "semantic",
+                    },
+                },
+                "required": True,
+            },
+            {
+                "id": "extra",
+                "type": "freeform",
+                "prompt": "Anything else?",
+                "binds": {
+                    "action": "remember",
+                    "params_template": {"content": f"Extra note {marker}: {{{{answer}}}}"},
+                },
+                "skippable": True,
+            },
+        ],
+    }
+    spec.update(overrides)
+    return spec
+
+
+async def test_start_hmx_interview_is_idempotent(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            marker = get_test_identifier("hmxinterview")
+            export_id = f"exp_{marker[:16]:0<16}"
+            spec = _interview(marker)
+
+            first = _j(
+                await conn.fetchval(
+                    "SELECT start_hmx_interview($1, $2::jsonb)", export_id, json.dumps(spec)
+                )
+            )
+            assert first["status"] == "pending"
+            assert first["export_id"] == export_id
+            assert len(first["questions"]) == 2
+
+            second = _j(
+                await conn.fetchval(
+                    "SELECT start_hmx_interview($1, $2::jsonb)", export_id, json.dumps(spec)
+                )
+            )
+            assert second["id"] == first["id"]
+        finally:
+            await tr.rollback()
+
+
+async def test_required_question_completes_interview_and_applies_remember_binding(
+    db_pool,
+):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            marker = get_test_identifier("hmxinterview")
+            export_id = f"exp_{marker[:16]:0<16}"
+            spec = _interview(marker)
+            await conn.fetchval(
+                "SELECT start_hmx_interview($1, $2::jsonb)", export_id, json.dumps(spec)
+            )
+
+            result = _j(
+                await conn.fetchval(
+                    "SELECT record_hmx_interview_answer($1, 'name', 'answered', $2::jsonb)",
+                    export_id,
+                    json.dumps("friend"),
+                )
+            )
+            assert result["success"] is True
+            assert result["binding_result"]["success"] is True
+            # 'name' is the only required question, so the interview is
+            # already complete even with 'extra' unanswered.
+            assert result["interview_status"] == "completed"
+
+            mem = await conn.fetchrow(
+                "SELECT content, source_attribution FROM memories WHERE content = $1",
+                f"The user {marker} wants to be called friend",
+            )
+            assert mem is not None
+            source = _j(mem["source_attribution"])
+            assert source["kind"] == "hmx_interview"
+            assert source["ref"] == export_id
+            assert source["label"] == "name"
+
+            state = _j(await conn.fetchval("SELECT get_hmx_interview_state($1)", export_id))
+            assert state["status"] == "completed"
+            assert len(state["answers"]) == 1
+        finally:
+            await tr.rollback()
+
+
+async def test_skipping_a_question_records_no_binding(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            marker = get_test_identifier("hmxinterview")
+            export_id = f"exp_{marker[:16]:0<16}"
+            spec = _interview(marker)
+            await conn.fetchval(
+                "SELECT start_hmx_interview($1, $2::jsonb)", export_id, json.dumps(spec)
+            )
+
+            result = _j(
+                await conn.fetchval(
+                    "SELECT record_hmx_interview_answer($1, 'extra', 'skipped')", export_id
+                )
+            )
+            assert result["success"] is True
+            assert result["binding_result"] is None
+
+            count = await conn.fetchval(
+                "SELECT count(*) FROM memories WHERE content LIKE $1",
+                f"Extra note {marker}:%",
+            )
+            assert count == 0
+        finally:
+            await tr.rollback()
+
+
+async def test_unimplemented_binding_action_fails_loud(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            marker = get_test_identifier("hmxinterview")
+            export_id = f"exp_{marker[:16]:0<16}"
+            spec = _interview(
+                marker,
+                questions=[
+                    {
+                        "id": "goal_q",
+                        "type": "freeform",
+                        "prompt": "What's a goal I should track?",
+                        "binds": {"action": "create_goal", "params_template": {"title": "{{answer}}"}},
+                    }
+                ],
+            )
+            await conn.fetchval(
+                "SELECT start_hmx_interview($1, $2::jsonb)", export_id, json.dumps(spec)
+            )
+
+            result = _j(
+                await conn.fetchval(
+                    "SELECT record_hmx_interview_answer($1, 'goal_q', 'answered', $2::jsonb)",
+                    export_id,
+                    json.dumps("ship the release"),
+                )
+            )
+            assert result["success"] is True  # recording the answer itself succeeded
+            assert result["binding_result"]["success"] is False
+            assert result["binding_result"]["error_type"] == "not_implemented"
+            assert "create_goal" in result["binding_result"]["error"]
+        finally:
+            await tr.rollback()
+
+
+async def test_unanswered_required_question_leaves_interview_pending(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            marker = get_test_identifier("hmxinterview")
+            export_id = f"exp_{marker[:16]:0<16}"
+            spec = _interview(marker)
+            await conn.fetchval(
+                "SELECT start_hmx_interview($1, $2::jsonb)", export_id, json.dumps(spec)
+            )
+
+            # Answer only the non-required question.
+            result = _j(
+                await conn.fetchval(
+                    "SELECT record_hmx_interview_answer($1, 'extra', 'answered', $2::jsonb)",
+                    export_id,
+                    json.dumps("nothing else"),
+                )
+            )
+            assert result["interview_status"] == "pending"
+
+            state = _j(await conn.fetchval("SELECT get_hmx_interview_state($1)", export_id))
+            assert state["status"] == "pending"
+        finally:
+            await tr.rollback()
+
+
+async def test_answering_unknown_question_id_is_a_clear_error(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            marker = get_test_identifier("hmxinterview")
+            export_id = f"exp_{marker[:16]:0<16}"
+            spec = _interview(marker)
+            await conn.fetchval(
+                "SELECT start_hmx_interview($1, $2::jsonb)", export_id, json.dumps(spec)
+            )
+
+            result = _j(
+                await conn.fetchval(
+                    "SELECT record_hmx_interview_answer($1, 'nonexistent', 'answered', $2::jsonb)",
+                    export_id,
+                    json.dumps("x"),
+                )
+            )
+            assert result["success"] is False
+            assert "unknown question id" in result["error"]
+        finally:
+            await tr.rollback()
+
+
+async def test_answering_with_no_interview_started_is_a_clear_error(db_pool):
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            result = _j(
+                await conn.fetchval(
+                    "SELECT record_hmx_interview_answer('exp_0000000000000000', 'name', 'answered', $1::jsonb)",
+                    json.dumps("x"),
+                )
+            )
+            assert result["success"] is False
+            assert "no interview in progress" in result["error"]
+        finally:
+            await tr.rollback()


### PR DESCRIPTION
Relates to #97 (partial implementation -- see scope below; not closing this issue since most of the surface area described there is still open).

## What this adds

A use case fully defined in one HMX file, first vertical slice:

1. **Open standard**: `schemas/hmx-1.7.schema.json` gains an optional `onboarding_interview` section -- `{version, questions: [{id, type: choice|freeform, prompt, options?, binds: {action, params_template}, required?, skippable?}]}`, matching the issue's spec sketch. Existing documents stay valid (the section is optional); `binds.action` is constrained to the seven action kinds the issue's binding table names, so the *contract* supports all of them even though only one is executed today (see below).

2. **Persistence**: `db/49a_hmx_onboarding_interview.sql` (+ `db/migrations/0250`) adds `hmx_interview_state`, keyed by the document's own `export_id`, so interview progress survives restarts and resumes mid-interview rather than restarting from question one. `record_hmx_interview_answer()` applies a question's binding and marks the interview complete once every `required` question has a recorded answer.

3. **One binding, wired for real**: `remember` creates an actual memory via the existing `execute_memory_tool('remember', ...)` path, with `{{answer}}` substituted into the author's `params_template` and provenance (`kind: hmx_interview`, `ref: export_id`, `label: question_id`) always attached regardless of what the template set. The other five documented bindings (`ingest`, `init_identity`, `create_goal`, `set_guardrail`, `create_scheduled_task`, `set_config`) are schema-valid today but fail loud with `error_type: not_implemented` if used -- never a silent no-op, per the project's "fail loud" rule.

4. **CLI surface**: `core/hmx_interview.py` runs the interview after `hexis hmx import` succeeds interactively (a tty, no `--json`), over the existing `questionary`-based prompt helpers in `apps/cli_prompts.py` -- choice questions render as arrow-key select, freeform as text entry, skippable questions offer a skip, required freeform questions re-ask until answered. A non-interactive run still starts (and persists) the interview state and tells the operator so, rather than silently doing nothing.

## Verification

```
tests/core/test_hmx_exchange.py::TestOnboardingInterviewSchema  (7 new) -- schema conformance:
  well-formed, freeform without options, required/skippable flags,
  missing binds, unknown binding action, option missing value,
  document without the section still validates
tests/db/test_hmx_onboarding_interview.py  (7 new) -- persistence + binding execution:
  idempotent start, required-question completion + remember binding creates
  a real memory with hmx_interview provenance, skip records no binding,
  unimplemented action fails loud, unanswered required question stays
  pending, clear errors for unknown question id / no interview started
tests/core/test_hmx_interview.py  (8 new) -- CLI orchestration logic (mocked
  DB + prompts): no-section no-op, non-interactive starts without
  prompting, already-completed short-circuits, choice+freeform answered
  end-to-end, skippable freeform skips on empty input, required freeform
  re-asks until answered, failed binding is counted and reported,
  already-answered questions aren't re-asked

tests/core/test_hmx_exchange.py tests/core/test_hmx_interview.py: 46 passed in 64.26s
tests/db/test_hmx_onboarding_interview.py: 7 passed in 31.83s
tests/core/test_hmx_exchange.py tests/cli/test_hmx_cli.py: 55 passed in 81.46s (full existing HMX CLI/exchange suite, unaffected)
```

I also ran the mechanism live end-to-end against a scratch dataset before writing the tests (start → answer with a real graph-linked `remember` binding → verify the created memory's provenance → skip a question → hit the unimplemented-action path → confirm final interview state), and re-verified `hexis migrate --status` reports `0250_hmx_onboarding_interview` applied cleanly.

## Not attempted (real scope left on the table)

- **Web UI button rendering** for multiple-choice questions (hexis-ui) -- the issue explicitly asks for this as the web surface; only the CLI is wired here.
- **An init-wizard-stage variant** -- only the `hexis hmx import` CLI path triggers the interview; `apps/hexis_init.py` isn't touched, and the other `import_hmx()` call sites (staged-review acceptance, protected-replacement flows) don't either.
- **Binding executors for the other five action kinds** (`ingest`, `init_identity`, `create_goal`, `set_guardrail`, `create_scheduled_task`, `set_config`) -- schema-valid, loudly rejected at execution time.
- **Change-journal / web-inbox notices** for consequential bindings, per the issue's "Dignity/consent" section.
- **Formal conformance-vector fixtures** for the open HMX standard beyond the schema-validation unit tests added here.

Given the size of the full spec (a new section of an open, versioned exchange format, two different UI rendering surfaces, and seven different binding executors touching identity/goals/guardrails/integrations), I scoped this to the smallest complete, tested slice that proves the mechanism end-to-end rather than attempting the whole surface at once. Happy to pick up any of the above in a follow-up if this direction looks right.

Noted in passing, unrelated to this change: `tests/db/test_hmx_staging.py::TestReviewDecisions::test_active_target_blocks_protected_acceptance` fails on current `main` on its own (verified via `git stash` before this branch existed) -- pre-existing, not introduced here, and not touched by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional onboarding interviews after successful CLI imports.
  * Supports conversational choice and freeform questions, including skipping and required-question prompts.
  * Displays interview notes, progress summaries, skipped questions, and binding failures.
  * Supports saving “remember” responses for future reference.
  * Added schema support for defining onboarding interviews in HMX documents.

* **Bug Fixes**
  * Prevents interviews from running in non-interactive or JSON output modes.
  * Preserves interview progress and safely handles completed or repeated interviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->