### PR TITLE
Add an Integrations doctor check for broken connector auth (partial #100)

### DIFF
--- a/core/cli_api.py
+++ b/core/cli_api.py
@@ -927,6 +927,57 @@ async def doctor_payload(
                 }
             )
 
+        # 8b. Integrations (#100): Gmail and every other OAuth/API-key
+        # connector share one status model (integration_connections.status).
+        # A broken connection is a silent dead end otherwise -- heartbeat
+        # skips it, and nothing tells the operator until they notice email
+        # triage stopped firing.
+        try:
+            status = await conn.fetchval("SELECT integration_status(NULL)")
+            payload = _coerce_json_value(status) or {}
+            connections = [c for c in payload.get("connections", []) if isinstance(c, dict)]
+            broken = [c for c in connections if c.get("status") in ("needs_reauth", "revoked", "error")]
+            healthy = [c for c in connections if c.get("status") == "connected"]
+            if broken:
+                names = ", ".join(
+                    f"{c.get('connector_id')} ({c.get('account_key')}): {c.get('status')}"
+                    + (f" — {c.get('last_error')}" if c.get("last_error") else "")
+                    for c in broken
+                )
+                checks.append(
+                    {
+                        "label": "Integrations",
+                        "status": "WARN",
+                        "detail": f"{len(broken)} connection(s) need attention: {names}. "
+                        "Reconnect via the web dashboard's Integrations page.",
+                    }
+                )
+            elif healthy:
+                names = ", ".join(f"{c.get('connector_id')} ({c.get('account_key')})" for c in healthy)
+                checks.append(
+                    {
+                        "label": "Integrations",
+                        "status": "OK",
+                        "detail": f"{len(healthy)} connected ({names})",
+                    }
+                )
+            else:
+                checks.append(
+                    {
+                        "label": "Integrations",
+                        "status": "WARN",
+                        "detail": "0 connected (Gmail, Spotify, etc. — connect one via the web dashboard's Integrations page)",
+                    }
+                )
+        except Exception as exc:
+            checks.append(
+                {
+                    "label": "Integrations",
+                    "status": "WARN",
+                    "detail": f"integration status unavailable ({exc})",
+                }
+            )
+
         # 9. Tools
         try:
             import asyncpg

--- a/tests/db/test_tool_reachability_audit.py
+++ b/tests/db/test_tool_reachability_audit.py
@@ -63,3 +63,51 @@ async def test_doctor_surfaces_reachability_and_audit_health(db_pool):  # noqa: 
     assert by_label["Tool reachability"]["status"] in {"OK", "WARN"}
     assert by_label["Tool reachability"]["detail"]
     assert by_label["Tool surface audit"]["status"] == "OK"
+
+
+async def test_doctor_surfaces_integration_health(db_pool):
+    """#100: a broken connector (e.g. Gmail needing reauth) is otherwise a
+    silent dead end -- heartbeat skips it, and nothing tells the operator
+    until they notice email triage stopped firing."""
+    from core.cli_api import doctor_payload
+    from tests.utils import _db_dsn
+
+    async with db_pool.acquire() as conn:
+        await conn.execute(
+            "DELETE FROM integration_connections WHERE connector_id = 'gmail'"
+        )
+    try:
+        no_connections = await doctor_payload(_db_dsn(), wait_seconds=2)
+        by_label = {c["label"]: c for c in no_connections}
+        assert by_label["Integrations"]["status"] == "WARN"
+        assert "0 connected" in by_label["Integrations"]["detail"]
+
+        async with db_pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO integration_connections (connector_id, account_key, status, last_error)
+                VALUES ('gmail', 'eric@example.com', 'needs_reauth', 'refresh token revoked by Google')
+                """
+            )
+        broken = await doctor_payload(_db_dsn(), wait_seconds=2)
+        by_label = {c["label"]: c for c in broken}
+        assert by_label["Integrations"]["status"] == "WARN"
+        assert "gmail" in by_label["Integrations"]["detail"]
+        assert "needs_reauth" in by_label["Integrations"]["detail"]
+        assert "refresh token revoked by Google" in by_label["Integrations"]["detail"]
+
+        async with db_pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE integration_connections SET status = 'connected', last_error = NULL "
+                "WHERE connector_id = 'gmail'"
+            )
+        healthy = await doctor_payload(_db_dsn(), wait_seconds=2)
+        by_label = {c["label"]: c for c in healthy}
+        assert by_label["Integrations"]["status"] == "OK"
+        assert "gmail" in by_label["Integrations"]["detail"]
+        assert "eric@example.com" in by_label["Integrations"]["detail"]
+    finally:
+        async with db_pool.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM integration_connections WHERE connector_id = 'gmail'"
+            )


### PR DESCRIPTION
Relates to #100 (partial -- see scope below; not closing since almost all of the issue's surface area is still open).

## Existing groundwork (verified against current `main` before scoping this)

This issue asks for a large subsystem, and a surprising amount of its "Initial Scope" already exists:

- **OAuth**: `core/auth/google_gmail.py` -- full sign-in flow, credential storage, refresh, expiry handling.
- **Read/search/list tools**: `core/tools/email.py` -- `EmailListHandler`, `EmailReadHandler`, `EmailSearchHandler`, all `allowed_contexts` including `HEARTBEAT`.
- **Send/reply/label/spam/delete tools**: `core/tools/gmail_actions.py` -- `GmailSendHandler`, `GmailReplyHandler`, `GmailLabelHandler`, `GmailSpamTriageHandler`, `GmailDeleteHandler`, every mutating one `requires_approval=True` and wired into the existing unified outbound-safety framework (`db/86b_functions_outbound_safety.sql`: purpose verification, contact budgets, quiet hours, STOP/opt-out, audit).
- **Heartbeat triage loop with dedupe**: `services/ambient_responsibilities.py::_evaluate_gmail` -- bounded inbox scanning, per-message observation storage, `_select_fire_items` dedupe, fired/silent/blocked outcomes.
- **Web-facing setup/status**: `apps/hexis_api.py` (`/api/integrations/status`, `/api/integrations/gmail/callback`) and `core/tools/integrations.py::GmailSetupStatusHandler` already expose granted scopes, connection status, pending attempts, memory policy, and heartbeat-digest opt-in.

## What was actually missing (this PR's scope)

None of that status was visible from the **CLI**. `hexis doctor` had zero mention of Gmail or any other connector -- a connection that needs reauth, was revoked, or hit a persistent error was a silent dead end: heartbeat's triage loop just stops firing for it, and nothing tells the operator until they notice email triage went quiet. That's a direct hit on this issue's own Safety Constraint ("doctor/setup must explain missing OAuth/scopes/policies and the exact next step") and its first Initial Scope bullet ("Gmail OAuth setup and status/doctor checks").

Added an **"Integrations" check** to `core/cli_api.py::doctor_payload()` (generalized to every connector via `integration_status(NULL)`, not just Gmail, since they all share one status model):

- 0 connections at all → `WARN`, pointing at the web dashboard's Integrations page (matches this same function's existing "Skills: 0 installed" / "Channels: 0 sessions" convention).
- Any connection `needs_reauth` / `revoked` / `error` → `WARN`, naming the connector, account, status, and `last_error`, with the reconnect next step. `WARN` rather than `FAIL` deliberately -- `hexis doctor`'s exit code goes non-zero on any `FAIL`, and a broken *optional* connector shouldn't flip that for the whole system.
- All connections healthy → `OK`, listing them.

## Verification

```
tests/db/test_tool_reachability_audit.py::test_doctor_surfaces_integration_health (new)
  -- 0 connections -> WARN; a needs_reauth Gmail connection -> WARN naming
  connector/account/status/last_error; reconnecting -> OK naming the account
tests/db/test_tool_reachability_audit.py: 4 passed in 32.89s
tests/core/test_pwa_access.py -k doctor: 1 passed
tests/db/test_consent_coherence.py: 1 passed
```

Also ran `hexis doctor` and `hexis doctor --json` against the live dev stack to confirm the check renders correctly in both the table and JSON output.

## Not attempted (the large majority of the issue)

- The graduated authorization/delegated-action policy engine (tiers 1-6 in the issue's Authorization Model) -- today's approval gate is binary (`requires_approval`), not a standing-policy system that can execute narrow pre-authorized actions without per-instance approval.
- An importance classifier deciding ignore/remember/notify/propose/act-with-approval/act-under-standing-authority -- today's ambient-triage loop is query-match-and-notify, not graded importance.
- Cross-channel escalation to a trusted contact.
- A dedicated email policy store (notification thresholds, spam directives, delegated-reply rules, trusted-contact bounds) beyond the generic connector/config settings that already exist.
- A user-visible policy review/revocation UI beyond the existing connector revoke action.

Given the safety stakes the issue itself calls out ("Samantha must not infer trusted contacts, permitted recipients, reply authority, or escalation channels from vibes alone"), I scoped this pass to a genuinely useful, low-risk, well-tested piece rather than building a delegated-autonomous-action policy engine in one autonomous pass without a design conversation first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Integrations health check to the diagnostic tool.
  * Reports connected integration counts and identifies connections requiring reauthorization or experiencing errors.
  * Displays connector details and the latest error message when available.
  * Warns when no integrations are connected or when the health check cannot be completed.

* **Tests**
  * Added coverage for disconnected, error, and successfully connected integration states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->