### PR TITLE
Stop fabricating a decision when the RLM heartbeat loop totally fails

### DIFF
--- a/db/92_functions_self_repair.sql
+++ b/db/92_functions_self_repair.sql
@@ -67,7 +67,15 @@ BEGIN
         summary := 'The operation exceeded its execution window and needs retry/backoff or workload reduction.';
     ELSIF error_text LIKE '%network error%'
        OR error_text LIKE '%http error%'
-       OR error_text LIKE '%rate limit%' THEN
+       OR error_text LIKE '%rate limit%'
+       -- DNS/name-resolution failures (#111): the exact class that hit a
+       -- provider outage in the wild ("[Errno -2] Name or service not
+       -- known") and previously fell through to the generic bucket below.
+       OR error_text LIKE '%name or service not known%'
+       OR error_text LIKE '%nodename nor servname%'
+       OR error_text LIKE '%temporary failure in name resolution%'
+       OR error_text LIKE '%getaddrinfo failed%'
+       OR error_text LIKE '%name resolution%' THEN
         category := 'network_or_provider';
         severity := 'medium';
         title := 'Provider/network failure: ' || component;

--- a/db/migrations/0251_dns_failure_classification.sql
+++ b/db/migrations/0251_dns_failure_classification.sql
@@ -1,0 +1,85 @@
+-- #111: classify_defect_event's network/provider bucket had no pattern for
+-- DNS/name-resolution failures -- the exact class that hit a real provider
+-- outage in the wild ("[Errno -2] Name or service not known"), which fell
+-- through to the generic execution_failure bucket instead. Re-applied here
+-- (rather than only in the baseline db/92_functions_self_repair.sql)
+-- because migration 0190_self_repair_defect_reports.sql already shipped an
+-- earlier CREATE OR REPLACE of this function; migrations apply after the
+-- baseline, so without this the old definition would win on every install.
+SET search_path = public, ag_catalog, "$user";
+
+CREATE OR REPLACE FUNCTION classify_defect_event(
+    p_component TEXT,
+    p_error TEXT,
+    p_context JSONB DEFAULT '{}'::jsonb
+) RETURNS JSONB
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+    component TEXT := COALESCE(NULLIF(btrim(p_component), ''), 'unknown');
+    error_text TEXT := lower(COALESCE(p_error, ''));
+    category TEXT := 'execution_failure';
+    severity TEXT := 'medium';
+    title TEXT;
+    summary TEXT;
+BEGIN
+    IF error_text LIKE '%unknown tool:%'
+       OR error_text LIKE '%unknown action:%'
+       OR error_text LIKE '%validation errors:%'
+       OR error_text LIKE '%missing required field:%'
+       OR error_text LIKE '%not allowed in % context%' THEN
+        category := 'tool_contract';
+        severity := 'medium';
+        title := 'Tool/action contract failure: ' || component;
+        summary := 'A tool, heartbeat action, or argument schema did not match the executor contract.';
+    ELSIF error_text LIKE '%embedding service%'
+       OR error_text LIKE '%connection refused%'
+       OR error_text LIKE '%failed to connect%'
+       OR error_text LIKE '%not reachable%' THEN
+        category := 'dependency_unavailable';
+        severity := 'high';
+        title := 'Dependency unavailable: ' || component;
+        summary := 'A required local service or dependency was unavailable when the agent tried to use it.';
+    ELSIF error_text LIKE '%not configured%'
+       OR error_text LIKE '%missing api key%'
+       OR error_text LIKE '%missing config%'
+       OR error_text LIKE '%credentials%' THEN
+        category := 'configuration';
+        severity := 'low';
+        title := 'Configuration needed: ' || component;
+        summary := 'The operation needs user/provider configuration rather than code repair.';
+    ELSIF error_text LIKE '%timed out%'
+       OR error_text LIKE '%timeout%' THEN
+        category := 'timeout';
+        severity := 'medium';
+        title := 'Timeout: ' || component;
+        summary := 'The operation exceeded its execution window and needs retry/backoff or workload reduction.';
+    ELSIF error_text LIKE '%network error%'
+       OR error_text LIKE '%http error%'
+       OR error_text LIKE '%rate limit%'
+       -- DNS/name-resolution failures (#111): the exact class that hit a
+       -- provider outage in the wild ("[Errno -2] Name or service not
+       -- known") and previously fell through to the generic bucket below.
+       OR error_text LIKE '%name or service not known%'
+       OR error_text LIKE '%nodename nor servname%'
+       OR error_text LIKE '%temporary failure in name resolution%'
+       OR error_text LIKE '%getaddrinfo failed%'
+       OR error_text LIKE '%name resolution%' THEN
+        category := 'network_or_provider';
+        severity := 'medium';
+        title := 'Provider/network failure: ' || component;
+        summary := 'The operation failed outside the local code path and may need retry or provider-specific handling.';
+    ELSE
+        title := 'Execution failure: ' || component;
+        summary := 'The agent observed a failed operation that needs inspection before repair.';
+    END IF;
+
+    RETURN jsonb_build_object(
+        'category', category,
+        'severity', severity,
+        'title', title,
+        'summary', summary
+    );
+END;
+$$;

--- a/services/external_calls.py
+++ b/services/external_calls.py
@@ -214,6 +214,21 @@ class ExternalCallProcessor:
             )
         except Exception as e:
             logger.exception("RLM heartbeat decision failed, falling back to legacy")
+            # #111: a total LLM failure used to be swallowed into a
+            # fabricated decision three layers down, so self-repair never
+            # saw it (record_defect_event's only caller is gated on a
+            # non-empty actions array). Record the real error here -- the
+            # one place that still holds it -- before falling back.
+            try:
+                await conn.fetchval(
+                    "SELECT record_defect_event($1, $2, $3, $4::jsonb)",
+                    "heartbeat",
+                    "llm.heartbeat",
+                    str(e),
+                    json.dumps({"heartbeat_id": heartbeat_id, "fallback": "legacy"}),
+                )
+            except Exception:
+                logger.exception("Failed to record defect event for RLM heartbeat failure")
             return await self._process_heartbeat_decision_call(conn, call_input)
 
         return result

--- a/services/hexis_rlm.py
+++ b/services/hexis_rlm.py
@@ -51,6 +51,16 @@ class FinalAnswerResolution:
     error: str | None = None
 
 
+class RlmLoopFailure(RuntimeError):
+    """The RLM loop got no usable LLM response at all (#111).
+
+    Raised instead of fabricating a well-formed-looking decision string, so
+    the caller's existing legacy-path fallback (services/external_calls.py)
+    actually runs, and the failure can be recorded as a real defect rather
+    than persisted as a heartbeat that "chose" to do nothing.
+    """
+
+
 def _workspace_metrics(workspace: RLMWorkspace) -> dict[str, Any]:
     """Return every retrieval/workspace counter the RLM can affect."""
     return {
@@ -322,6 +332,12 @@ def _run_loop(
 
     final_answer: str | None = None
     iteration_count = 0
+    # The real cause of an early exit (#111): distinct from genuinely
+    # exhausting max_iterations with real (if unresolved) responses, so the
+    # exhaustion log below reports what actually happened instead of always
+    # blaming the configured limit, and so a total failure can raise instead
+    # of silently fabricating a decision.
+    loop_error: str | None = None
 
     for i in range(max_iterations):
         iteration_count = i + 1
@@ -340,6 +356,7 @@ def _run_loop(
             response = future.result(timeout=120)
         except Exception as e:
             logger.error("LLM call failed at iteration %d: %s", i, e)
+            loop_error = str(e)
             break
 
         if not response:
@@ -393,10 +410,20 @@ def _run_loop(
 
     # If we ran out of iterations without a FINAL, use the last response
     if final_answer is None:
-        logger.warning(
-            "RLM loop exhausted %d iterations without FINAL, using last response",
-            max_iterations,
-        )
+        if loop_error:
+            # An LLM call itself failed (#111) -- this is not "used up all
+            # its iterations thinking," it's a real infrastructure failure
+            # after iteration_count response(s). Report the true cause.
+            logger.warning(
+                "RLM loop broke early after %d iteration(s) (%s); attempting one repair call",
+                iteration_count,
+                loop_error,
+            )
+        else:
+            logger.warning(
+                "RLM loop exhausted %d iterations without FINAL, using last response",
+                max_iterations,
+            )
         # Make one more call asking for a final answer
         message_history.append({
             "role": "user",
@@ -426,8 +453,15 @@ def _run_loop(
                     )
                 else:
                     final_answer = response
-        except Exception:
-            final_answer = '{"reasoning": "RLM loop timed out", "actions": [], "goal_changes": []}'
+        except Exception as repair_exc:
+            # Both the main loop AND the repair call failed to get any real
+            # LLM response -- a total failure, not a decision. Raising here
+            # (rather than fabricating a well-formed-looking decision, #111)
+            # lets the caller's existing legacy-path fallback actually run,
+            # and the real error surface instead of a fictitious "timed out."
+            reason = loop_error or str(repair_exc)
+            logger.error("RLM loop got no usable LLM response at all: %s", reason)
+            raise RlmLoopFailure(reason) from repair_exc
 
     return {
         "final_answer": final_answer,
@@ -681,6 +715,17 @@ async def run_chat_turn(
         logger.error("RLM chat timed out after %ds", timeout_seconds)
         result = {
             "final_answer": "I apologize, but I need more time to think about that. Could you try again?",
+            "iterations": 0,
+            "message_count": 0,
+        }
+    except RlmLoopFailure as exc:
+        # #111: a total LLM failure -- unlike the heartbeat path (which lets
+        # this propagate so the legacy-path fallback can actually run), a
+        # chat turn has no fallback provider to hand off to and must still
+        # answer the user, honestly, rather than crash the request.
+        logger.error("RLM chat got no usable LLM response at all: %s", exc)
+        result = {
+            "final_answer": "I'm having trouble reaching my model provider right now. Please try again in a moment.",
             "iterations": 0,
             "message_count": 0,
         }

--- a/services/slow_ingest_rlm.py
+++ b/services/slow_ingest_rlm.py
@@ -18,6 +18,7 @@ from typing import Any
 from core.cognitive_memory_api import RelationshipType
 from core.memory_repo import MemoryRepo
 from services.hexis_rlm import (
+    RlmLoopFailure,
     _make_sync_llm_query,
     _run_loop,
     find_final_answer,
@@ -179,6 +180,27 @@ async def run_slow_ingest_chunk(
                 "iterations": 0,
                 "message_count": 0,
                 "timed_out": True,
+                "duration_seconds": round(duration, 2),
+            },
+        }
+    except RlmLoopFailure as exc:
+        # #111: a total LLM failure -- same honest degrade as the timeout
+        # branch above (a default, conservative assessment) rather than
+        # letting a fabricated decision or an unhandled crash reach the
+        # ingestion pipeline.
+        logger.error(
+            "slow_ingest_chunk got no usable LLM response chunk=%d/%d: %s",
+            chunk_index + 1,
+            total_chunks,
+            exc,
+        )
+        duration = time.perf_counter() - time_start
+        return {
+            "assessment": dict(_DEFAULT_ASSESSMENT),
+            "metrics": {
+                "iterations": 0,
+                "message_count": 0,
+                "llm_error": str(exc),
                 "duration_seconds": round(duration, 2),
             },
         }

--- a/tests/db/test_self_repair.py
+++ b/tests/db/test_self_repair.py
@@ -74,6 +74,104 @@ async def test_heartbeat_action_failures_create_diagnosable_defect_reports(db_po
     assert "Tool/action contract failure" in context
 
 
+async def test_dns_failure_classifies_as_network_or_provider(db_pool):
+    """#111: a real-world provider outage manifested as a Python DNS error
+    ("[Errno -2] Name or service not known"), which previously had no
+    matching pattern and fell into the generic execution_failure bucket."""
+    async with db_pool.acquire() as conn:
+        classification = _j(
+            await conn.fetchval(
+                "SELECT classify_defect_event('llm.heartbeat', $1)",
+                "[Errno -2] Name or service not known",
+            )
+        )
+    assert classification["category"] == "network_or_provider"
+
+
+async def test_heartbeat_llm_total_failure_creates_a_defect_report(db_pool):
+    """#111: a total LLM failure during heartbeat decision-making (both the
+    main loop and the repair call failed) must be recorded, not silently
+    swallowed -- this is the exact call self-repair otherwise never sees,
+    since record_heartbeat_action_defects is gated on a non-empty actions
+    array and a total failure produces zero actions."""
+    async with db_pool.acquire() as conn:
+        tr = conn.transaction()
+        await tr.start()
+        try:
+            defect_id = await conn.fetchval(
+                "SELECT record_defect_event($1, $2, $3, $4::jsonb)",
+                "heartbeat",
+                "llm.heartbeat",
+                "[Errno -2] Name or service not known",
+                json.dumps({"heartbeat_id": str(uuid4()), "fallback": "legacy"}),
+            )
+            row = await conn.fetchrow(
+                "SELECT category, severity, source, component, last_error "
+                "FROM defect_reports WHERE id = $1::uuid",
+                defect_id,
+            )
+        finally:
+            await tr.rollback()
+
+    assert row["category"] == "network_or_provider"
+    assert row["source"] == "heartbeat"
+    assert row["component"] == "llm.heartbeat"
+    assert "Name or service not known" in row["last_error"]
+
+
+async def test_rlm_heartbeat_total_failure_records_defect_then_falls_back(
+    db_pool, monkeypatch
+):
+    """#111 end to end at the dispatcher level: an RLM heartbeat decision
+    that fails completely (a) records a real defect (the exact case
+    record_heartbeat_action_defects can never see, since a total failure
+    produces zero actions) and (b) still falls back to the legacy path
+    rather than fabricating a decision or losing the heartbeat's turn."""
+    import services.external_calls as external_calls_mod
+    from services.external_calls import ExternalCallProcessor
+    from services.hexis_rlm import RlmLoopFailure
+
+    heartbeat_id = str(uuid4())
+
+    async def fake_run_heartbeat_decision(**_kwargs):
+        raise RlmLoopFailure("[Errno -2] Name or service not known")
+
+    legacy_decision = {"reasoning": "legacy fallback", "actions": [], "goal_changes": []}
+
+    async def fake_chat_json(**_kwargs):
+        return legacy_decision, json.dumps(legacy_decision)
+
+    monkeypatch.setattr(
+        "services.hexis_rlm.run_heartbeat_decision", fake_run_heartbeat_decision
+    )
+    monkeypatch.setattr(external_calls_mod, "chat_json", fake_chat_json)
+
+    processor = ExternalCallProcessor()
+    async with db_pool.acquire() as conn:
+        before = await conn.fetchval(
+            "SELECT count(*) FROM defect_reports WHERE component = 'llm.heartbeat'"
+        )
+        result = await processor.process_call_payload(
+            conn,
+            "think",
+            {"kind": "heartbeat_decision_rlm", "heartbeat_id": heartbeat_id, "context": {}},
+        )
+        after = await conn.fetchval(
+            "SELECT count(*) FROM defect_reports WHERE component = 'llm.heartbeat'"
+        )
+        row = await conn.fetchrow(
+            "SELECT category, last_error FROM defect_reports "
+            "WHERE component = 'llm.heartbeat' ORDER BY created_at DESC LIMIT 1"
+        )
+
+    assert after == before + 1
+    assert row["category"] == "network_or_provider"
+    assert "Name or service not known" in row["last_error"]
+    # The legacy fallback actually ran and produced the real decision.
+    assert result["kind"] == "heartbeat_decision"
+    assert result["decision"] == legacy_decision
+
+
 async def test_chat_continuity_surfaces_unresolved_defects(db_pool):
     marker = uuid4().hex
     heartbeat_id = str(uuid4())

--- a/tests/services/test_rlm_heartbeat.py
+++ b/tests/services/test_rlm_heartbeat.py
@@ -403,3 +403,114 @@ class TestLegacyPathUnchanged:
             if calls:
                 call_input = calls[0].get("input", {})
                 assert call_input.get("kind") == "heartbeat_decision"
+
+
+class TestTotalLlmFailure:
+    """#111: a total LLM failure inside _run_loop must raise, not fabricate
+    a well-formed-looking decision string ('RLM loop timed out' with empty
+    actions) that gets persisted as a real, successful heartbeat."""
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_run_loop_raises_when_every_llm_call_fails(self, monkeypatch):
+        import services.hexis_rlm as rlm
+        from services.rlm_repl import HexisLocalREPL
+
+        async def always_fails(messages, llm_config, max_tokens=4096):
+            raise ConnectionError("[Errno -2] Name or service not known")
+
+        monkeypatch.setattr(rlm, "_llm_completion", always_fails)
+
+        repl = HexisLocalREPL()
+        repl.setup(context_payload="heartbeat")
+        loop = asyncio.get_running_loop()
+        try:
+            with pytest.raises(rlm.RlmLoopFailure, match="Name or service not known"):
+                await loop.run_in_executor(
+                    None,
+                    rlm._run_loop,
+                    repl,
+                    {"provider": "test", "model": "test"},
+                    loop,
+                    "system",
+                    3,
+                )
+        finally:
+            repl.cleanup()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_run_loop_does_not_raise_if_repair_call_succeeds(self, monkeypatch):
+        """The main loop failing is not itself a total failure -- only a
+        failure of the one-more-chance repair call after it is."""
+        import services.hexis_rlm as rlm
+        from services.rlm_repl import HexisLocalREPL
+
+        calls = {"n": 0}
+
+        async def fails_then_recovers(messages, llm_config, max_tokens=4096):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ConnectionError("[Errno -2] Name or service not known")
+            return "FINAL(recovered)"
+
+        monkeypatch.setattr(rlm, "_llm_completion", fails_then_recovers)
+
+        repl = HexisLocalREPL()
+        repl.setup(context_payload="heartbeat")
+        loop = asyncio.get_running_loop()
+        try:
+            result = await loop.run_in_executor(
+                None,
+                rlm._run_loop,
+                repl,
+                {"provider": "test", "model": "test"},
+                loop,
+                "system",
+                1,
+            )
+        finally:
+            repl.cleanup()
+
+        assert result["final_answer"] == "recovered"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_run_chat_turn_answers_honestly_on_total_failure(self, monkeypatch):
+        """The chat path has no legacy fallback to hand off to, so it must
+        still answer the user -- honestly, not with a fabricated decision."""
+        import services.hexis_rlm as rlm
+
+        async def always_fails(messages, llm_config, max_tokens=4096):
+            raise ConnectionError("[Errno -2] Name or service not known")
+
+        monkeypatch.setattr(rlm, "_llm_completion", always_fails)
+
+        result = await rlm.run_chat_turn(
+            user_message="hello",
+            llm_config={"provider": "test", "model": "test"},
+            dsn="postgresql://unused/unused",
+            max_iterations=1,
+        )
+        assert "trouble reaching" in result["response"]
+        assert result["metrics"]["iterations"] == 0
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_run_heartbeat_decision_propagates_total_failure(self, monkeypatch):
+        """The heartbeat path, unlike chat, has a legacy-path fallback one
+        level up (services/external_calls.py) -- so it must let a total
+        failure propagate as a real exception rather than swallow it."""
+        import services.hexis_rlm as rlm
+
+        async def always_fails(messages, llm_config, max_tokens=4096):
+            raise ConnectionError("[Errno -2] Name or service not known")
+
+        monkeypatch.setattr(rlm, "_llm_completion", always_fails)
+
+        with pytest.raises(rlm.RlmLoopFailure):
+            await rlm.run_heartbeat_decision(
+                heartbeat_id="test-hb",
+                turn_snapshot={"energy": {"current": 10}},
+                llm_config={"provider": "test", "model": "test"},
+                dsn="postgresql://unused/unused",
+                tool_registry=None,
+                loop=asyncio.get_running_loop(),
+                max_iterations=1,
+            )


### PR DESCRIPTION
Closes #111.

## The bug (confirmed still present on `main`, exactly as reported)

A total LLM outage during a heartbeat (observed in the wild: `[Errno -2] Name or service not known`, a DNS failure reaching the provider) was swallowed at `services/hexis_rlm.py`'s `_run_loop` terminal fallback:

```python
except Exception:
    final_answer = '{"reasoning": "RLM loop timed out", "actions": [], "goal_changes": []}'
```

This is well-formed JSON matching the decision contract exactly, factually wrong (it wasn't a timeout), and completely unlogged. Every downstream consumer (`apply_heartbeat_decision` → `complete_heartbeat`) treated it as a real decision: the heartbeat completed cleanly, regenerated +10 energy, and wrote a false episodic memory ("Heartbeat #N: No actions taken") implying the agent consciously chose to do nothing. `record_heartbeat_action_defects` -- the only caller of `record_defect_event` -- is gated on a non-empty actions array, so self-repair never saw any of it. A sustained outage would look like an unbroken run of successful, maximally-rested heartbeats.

## Fix

- **`_run_loop`** now tracks the real exception from the main iteration loop (previously discarded after the `break`), reports the true cause and actual iteration count in its exhaustion log (previously always blamed the configured max, regardless of whether it actually ran that many iterations), and -- when the one-more-chance repair call *also* fails -- raises `RlmLoopFailure(real_error)` instead of fabricating a decision.
- **`run_heartbeat_decision`** has no handler for `RlmLoopFailure`, so it propagates naturally through the existing `try/except asyncio.TimeoutError` (a different exception type) straight out of the function -- to `services/external_calls.py`'s existing `except Exception: ... fall back to legacy` handler at the RLM-heartbeat-decision call site. That fallback path already existed and was designed for exactly this, but was dead code because the failure was never allowed to raise. It now also calls `record_defect_event('heartbeat', 'llm.heartbeat', <real error>, ...)` before falling back, so self-repair finally sees this class of failure -- point 6 in the issue ("self-repair can't see it").
- **`run_chat_turn`** and **`run_slow_ingest_chunk`** share `_run_loop` but have no legacy path to fall back to, so each gets its own honest degrade instead of an unhandled crash or (previously) a silently fabricated result: chat answers "I'm having trouble reaching my model provider right now. Please try again in a moment."; ingestion returns the existing conservative default assessment (same shape as its timeout branch).
- **`classify_defect_event`** had no pattern for DNS/name-resolution failures -- the exact class actually observed -- so it fell into the generic `execution_failure` bucket instead of the already-existing `network_or_provider` category the issue points at. Added the missing patterns. This required a new migration (0251) rather than only a baseline edit: `db/migrations/0190_self_repair_defect_reports.sql` already ships an earlier `CREATE OR REPLACE` of this same function, and migrations apply after the baseline, so without a newer migration the old definition would silently win on every install (I hit this myself -- see Verification).

## Verification

```
tests/services/test_rlm_heartbeat.py::TestTotalLlmFailure (4 new):
  - _run_loop raises RlmLoopFailure when every LLM call fails
  - _run_loop does NOT raise when the main loop fails but the repair call recovers
  - run_chat_turn answers honestly instead of crashing or fabricating
  - run_heartbeat_decision propagates the failure (for the legacy fallback to catch)
tests/db/test_self_repair.py (2 new):
  - classify_defect_event('llm.heartbeat', '[Errno -2] Name or service not known')
    -> network_or_provider (was execution_failure)
  - record_defect_event with that error produces a correctly-categorized row
  - test_rlm_heartbeat_total_failure_records_defect_then_falls_back: dispatcher-level
    end-to-end -- ExternalCallProcessor.process_call_payload with a mocked
    run_heartbeat_decision that raises RlmLoopFailure both records the defect
    AND still returns the real legacy-path decision (proves the fallback actually runs)

tests/services/test_rlm_heartbeat.py tests/services/test_rlm_chat.py: 30 passed in 95.03s
tests/db/test_self_repair.py: 5 passed in 32.88s
tests/core/test_slow_ingest_dedup.py: included in the 31-test sweep above, unaffected
```

I initially wrote the migration-less version of the `classify_defect_event` fix, ran the isolated test suite, and hit exactly the 0190-shadowing problem described above (`network_or_provider` assertion failed with `execution_failure`) -- traced it, added migration 0251, and it passed. Left that discovery in the commit message since it's a real, generally-applicable gotcha for anyone editing an old, already-migrated baseline function.

**Noted in passing, unrelated to this change:** `tests/db/test_db.py::test_worker_end_to_end_heartbeat_with_follow_on_calls` fails on current `main` on its own (verified via `git stash` before this branch existed) -- a goal-count assertion (`0 == 2`), pre-existing, not touched by this PR.

## Not attempted

The issue ranks 5 fixes; this PR covers #1 (swallow sites + defect recording) and part of #3 (a DB-visible defect now exists, though not a hard *schema* backstop on zero-action heartbeats specifically). Left for follow-up, each a real and separate change:

- **#2**: Reworking the gateway/`worker_service.py` control flow so `GatewayConsumer`/`gateway.fail` actually gets used on this path, and the energy model so a heartbeat that did zero work doesn't regenerate +10 energy as if it succeeded. This touches the heartbeat completion/energy pipeline broadly and deserves its own focused pass.
- **#4**: Wrapping the non-retrying LLM provider branches (`minimax-portal` / `google-gemini-cli` / `google-antigravity` in `core/llm.py`) in `_retry_on_transient` so a single transient DNS blip doesn't reach `_run_loop`'s failure path at all. I didn't verify the `duration=0.0s` inference in the issue's point 8; that needs its own investigation of `core/llm.py`'s per-provider call paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DNS and name-resolution failures are now categorized as network/provider issues instead of generic execution failures.
  * Complete AI processing failures no longer appear as misleading timeouts.
  * Chat and ingestion workflows now provide honest fallback responses or conservative assessments when AI services are unavailable.
  * Heartbeat processing records AI failures and automatically falls back to the legacy decision path.

* **Reliability**
  * Improved failure reporting and recovery for heartbeat, chat, and ingestion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->