### PR TITLE
Stop ingestion appraisals from overwriting live affective state

### DIFF
--- a/services/ingest/config.py
+++ b/services/ingest/config.py
@@ -217,15 +217,6 @@ class Appraisal:
     curiosity: float = 0.0
     summary: str = ""
 
-    def to_state_payload(self, source: str = "ingest") -> dict[str, Any]:
-        return {
-            "valence": self.valence,
-            "arousal": self.arousal,
-            "primary_emotion": self.primary_emotion,
-            "intensity": self.intensity,
-            "source": source,
-        }
-
 
 @dataclass
 class Extraction:

--- a/services/ingest/pipeline.py
+++ b/services/ingest/pipeline.py
@@ -592,15 +592,24 @@ class IngestionPipeline:
         base_context = await self._build_appraisal_context(doc)
         use_deep = doc.word_count <= self.config.deep_max_words
 
-        overall_appraisal = None
-        if not use_deep:
-            sample = self._sample_content(content)
-            overall_appraisal = await self.appraiser.appraise(content=sample, context=base_context, mode=mode)
-            await self.store.set_affective_state(overall_appraisal)
-            metrics.appraisal_valence = overall_appraisal.valence
-            metrics.appraisal_arousal = overall_appraisal.arousal
-            metrics.appraisal_emotion = overall_appraisal.primary_emotion
-            metrics.appraisal_intensity = overall_appraisal.intensity
+        # #86: ingestion appraisals no longer overwrite the live affective
+        # state (store.set_affective_state used to slam
+        # set_current_affective_state -- once per doc here, once per
+        # SECTION in the deep branch below, last-write-wins over whatever
+        # the agent was actually feeling mid-conversation). Reading still
+        # feels like something, but that feeling is recorded on the
+        # encounter memory's own emotional_valence -- update_mood()
+        # blends it into mood from there over the normal maintenance
+        # cycle, the same as any other episodic memory's affect. A
+        # doc-level sample is computed unconditionally now (previously
+        # only for non-deep docs) so a small document's encounter memory
+        # gets its own real appraisal instead of a neutral default.
+        sample = self._sample_content(content)
+        overall_appraisal = await self.appraiser.appraise(content=sample, context=base_context, mode=mode)
+        metrics.appraisal_valence = overall_appraisal.valence
+        metrics.appraisal_arousal = overall_appraisal.arousal
+        metrics.appraisal_emotion = overall_appraisal.primary_emotion
+        metrics.appraisal_intensity = overall_appraisal.intensity
 
         encounter_id = receipts.get(f"enc:{doc_ref}")
         if encounter_id is None:
@@ -646,7 +655,10 @@ class IngestionPipeline:
                 *[_appraise_and_extract(s) for s in active_sections]
             )
             for section, (appraisal, extractions) in zip(active_sections, deep_results):
-                await self.store.set_affective_state(appraisal)
+                # #86: per-section appraisals still shape extraction/decay
+                # (below) and metrics, but no longer overwrite live
+                # affective state -- that was the "30 times in quick
+                # succession" thrash this issue is about.
                 metrics.appraisal_valence = appraisal.valence
                 metrics.appraisal_arousal = appraisal.arousal
                 metrics.appraisal_emotion = appraisal.primary_emotion

--- a/services/ingest/store.py
+++ b/services/ingest/store.py
@@ -26,7 +26,7 @@ from core.cognitive_memory_api import (
     RelationshipType,
 )
 
-from .config import Appraisal, Config, IngestionMetrics
+from .config import Config, IngestionMetrics
 
 # =========================================================================
 # STORAGE
@@ -301,15 +301,6 @@ class MemoryStore:
             document_id,
             original_hash,
         )
-
-    async def set_affective_state(self, appraisal: Appraisal) -> None:
-        if self.client is None:
-            await self.connect()
-        payload = json.dumps(appraisal.to_state_payload(source="ingest"))
-        try:
-            await self._fetchval("SELECT set_current_affective_state($1::jsonb)", payload)
-        except Exception:
-            pass
 
     async def create_encounter_memory(
         self,

--- a/tests/services/test_ingest_source_documents.py
+++ b/tests/services/test_ingest_source_documents.py
@@ -325,6 +325,112 @@ async def test_ingest_created_memories_carry_source_document_id(db_pool):
             await conn.execute("DELETE FROM ingestion_receipts WHERE doc_ref = $1", content_hash)
 
 
+class _AppraisalStubLLM(_StubLLM):
+    """Like _StubLLM, but the appraisal branch returns a distinctive,
+    non-neutral valence so a test can tell "the appraisal landed here" apart
+    from "nothing happened" or "the default neutral value happened to match"."""
+
+    def __init__(self, marker: str, valence: float = 0.85):
+        super().__init__(marker)
+        self.valence = valence
+
+    async def complete_json(self, messages, temperature=0.2):
+        text = str(messages[-1].get("content", ""))
+        if "key 'items'" in text:
+            return await super().complete_json(messages, temperature)
+        return {
+            "valence": self.valence,
+            "arousal": 0.7,
+            "primary_emotion": "delight",
+            "intensity": 0.8,
+            "summary": "The document was delightful.",
+        }
+
+
+async def test_ingest_does_not_overwrite_live_affective_state(db_pool):
+    """#86: a document's appraisal must not slam the shared, live affective
+    state -- once per document, let alone once per section for small docs.
+    The felt signal belongs on the encounter memory; update_mood() blends it
+    into mood from there over the normal maintenance cycle, like any other
+    episodic memory's affect."""
+    marker = get_test_identifier("ingestaffect")
+    content = (
+        f"# Reading {marker}\n\nFirst section talks about something notable.\n\n"
+        f"## Second\n\nA second section, so the per-section (FAST deep) path runs.\n\n"
+        f"## Third\n\nA third section for good measure."
+    )
+    content_hash = _hash_text(content)
+    sentinel = json.dumps({
+        "valence": -0.9,
+        "arousal": 0.9,
+        "primary_emotion": "sentinel_marker_emotion",
+        "intensity": 0.9,
+        "dominance": 0.5,
+    })
+
+    async with db_pool.acquire() as conn:
+        await _stub_get_embedding(conn)
+        original_state = await conn.fetchval(
+            "SELECT affective_state FROM heartbeat_state WHERE id = 1"
+        )
+        await conn.execute(
+            "UPDATE heartbeat_state SET affective_state = affective_state || $1::jsonb WHERE id = 1",
+            sentinel,
+        )
+
+    config = Config(
+        dsn=_db_dsn(os.environ.get("POSTGRES_DB")),
+        llm_config={"provider": "openai", "model": "stub", "api_key": "stub"},
+        mode=IngestionMode.FAST,
+        deep_max_words=2000,  # well above this doc's word count -> per-section path
+        verbose=False,
+    )
+    pipeline = IngestionPipeline(config)
+    pipeline.llm = _AppraisalStubLLM(marker)
+    pipeline.appraiser.llm = pipeline.llm
+    pipeline.extractor.llm = pipeline.llm
+    try:
+        try:
+            await pipeline.ingest_text(content, title=f"Reading {marker}")
+        finally:
+            await pipeline.close()
+
+        async with db_pool.acquire() as conn:
+            live_state = await conn.fetchval(
+                "SELECT get_current_affective_state()"
+            )
+            live_state = json.loads(live_state) if isinstance(live_state, str) else live_state
+            assert live_state["primary_emotion"] == "sentinel_marker_emotion"
+            assert live_state["valence"] == -0.9
+
+            encounter = await conn.fetchrow(
+                "SELECT metadata->>'emotional_valence' AS emotional_valence FROM memories "
+                "WHERE type = 'episodic' AND content LIKE $1",
+                f"I read 'Reading {marker}'.%",
+            )
+        assert encounter is not None
+        # The felt signal from ingestion landed on the encounter memory, not
+        # on the live state the sentinel proved untouched above.
+        assert abs(float(encounter["emotional_valence"]) - 0.85) < 1e-9
+    finally:
+        async with db_pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE heartbeat_state SET affective_state = $1::jsonb WHERE id = 1",
+                json.dumps(original_state) if not isinstance(original_state, str) else original_state,
+            )
+            await conn.execute(
+                "DELETE FROM subconscious_units WHERE source_attribution->>'content_hash' = $1",
+                content_hash,
+            )
+            await conn.execute(
+                "DELETE FROM memories WHERE content LIKE $1 OR source_attribution->>'content_hash' = $2",
+                f"I read 'Reading {marker}'.%",
+                content_hash,
+            )
+            await conn.execute("DELETE FROM source_documents WHERE content_hash = $1", content_hash)
+            await conn.execute("DELETE FROM ingestion_receipts WHERE doc_ref = $1", content_hash)
+
+
 @pytest.mark.parametrize(
     ("mode", "runner_name"),
     [


### PR DESCRIPTION
Closes #86.

## The bug (confirmed still present -- the file moved, the bug didn't)

`services/ingest.py` from the issue is now the `services/ingest/` package, but `IngestionPipeline`'s core loop still called `store.set_affective_state(appraisal)` -- a hard overwrite via `set_current_affective_state()` -- exactly as described:

- **Doc-level (large docs):** once per document.
- **Per-section (FAST "deep" mode, docs ≤ `deep_max_words`, default 2000 words):** once per section, in a tight loop over every section in the document.

`set_current_affective_state` merges the new payload's keys (`valence`, `arousal`, `primary_emotion`, `intensity`, `dominance`) directly over the current state (`current || new`) -- not a blend, a replace. A 30-section document slams that 30 times; whatever the last section happened to feel like wins, silently overwriting whatever affect the agent was actually carrying from live conversation -- including mid-conversation, since a background `hexis ingest` run shares the same singleton `heartbeat_state` row.

## Fix

Removed both call sites of `store.set_affective_state`. The "reading feels like something" signal isn't lost -- it now goes through the path the issue's own "Expected" section names as acceptable: **recorded on the encounter memory only, letting retention/consolidation move the mood.**

- `_create_encounter_memory` already stamps `emotional_valence` on the one encounter memory it creates per document.
- `update_mood()` (`db/28_functions_dopamine.sql`) already runs periodically and blends recent episodic memories' `emotional_valence` into `mood_valence`/`mood_arousal` via a genuine weighted average (`old * (1 - decay_rate) + recent_avg * decay_rate`) -- this *is* "the same blending path" the issue references; conversation appraisals reach mood the same way, through the memory's own `emotional_valence`, not a direct `set_current_affective_state` call. No new blending mechanism was needed.

One real gap this surfaced: in per-section ("deep") mode, `overall_appraisal` was `None`, so `_create_encounter_memory` always recorded a *neutral default* for "how did reading this feel" -- even though N real per-section appraisals had just been computed (and, until now, thrown at global state instead of anywhere durable). Fixed by computing the doc-level appraisal sample unconditionally now, so small documents' encounter memories get a real appraisal too, matching what large documents already got. Per-section appraisals are otherwise unchanged -- still drive each section's extraction context and decay intensity.

Also removed the now-dead `Appraisal.to_state_payload()` and `IngestStore.set_affective_state()` rather than leaving them as an invitation to reintroduce the same overwrite later.

## Verification

New test in `tests/services/test_ingest_source_documents.py`:
- `test_ingest_does_not_overwrite_live_affective_state` -- sets a distinctive sentinel on the live affective state, ingests a 3-section document (FAST/deep path) with a stub LLM whose appraisal returns a different, distinctive valence (0.85/"delight"), and asserts **both**: the live state is still exactly the sentinel (untouched), and the appraisal's valence landed on the encounter memory's `metadata->>'emotional_valence'`.

```
tests/services/test_ingest_source_documents.py: 8 passed in 33.63s
tests/services/test_ingest_resume.py tests/services/test_ingest_chunks.py tests/services/test_ingest_artifact_jobs.py: 7 passed in 97.26s
tests/core/test_ingest_tools.py tests/core/test_slow_ingest_dedup.py tests/core/test_email_ingestion.py tests/core/test_url_ingest.py: 124 passed
```

`ruff check` on the touched files shows the same pre-existing unused-import count before and after this change (verified via `git stash`) -- nothing new introduced; I did clean up the one import (`Appraisal` in `services/ingest/store.py`) that became newly dead from removing `set_affective_state`.

No DB migration needed -- this is a pure Python change; `set_current_affective_state` and `update_mood()` themselves are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented document ingestion from overwriting the assistant’s live emotional state.
  * Preserved appraisal signals in encounter memories for later use.
  * Ensured emotional state remains stable during multi-section document processing.

* **Tests**
  * Added coverage confirming ingestion preserves existing live affective state while recording appraisal data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->