### PR TITLE
ci: bump actions/setup-python from 5 to 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
Recreates #106 fresh on current `main` — that branch has 30+ days of unresolved conflicts with automatic rebase disabled, and its last CI run predates this session's work by a month, failing on an unrelated, expected AGE-catalog guard (not this bump).

Same change dependabot proposed: `actions/setup-python@v5` → `@v7` across both workflow files. v7 migrated to ESM and dropped EOL Python version support (we pin 3.12, unaffected) — no input/output changes for our usage (`python-version` + `cache: pip`).

Will close #106 once this merges and CI is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Python environment setup used by automated validation and package publishing workflows.
  * No user-facing functionality or workflow behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->