### PR TITLE
Fix flaky async assertions in forgetting/learning-review tests

### DIFF
--- a/hexis-ui/app/forgetting/page.test.tsx
+++ b/hexis-ui/app/forgetting/page.test.tsx
@@ -82,7 +82,7 @@ describe("forgetting", () => {
       decision: "journal",
       journal_content: "Keep the lesson, not every launch detail.",
     }));
-    expect(screen.getByText(/1 source memory entered one recoverable gist/)).toBeInTheDocument();
+    expect(await screen.findByText(/1 source memory entered one recoverable gist/)).toBeInTheDocument();
   });
 
   it("reports exact source count and stored fidelity after compression", async () => {

--- a/hexis-ui/app/learning-review/page.test.tsx
+++ b/hexis-ui/app/learning-review/page.test.tsx
@@ -67,7 +67,7 @@ describe("learning review", () => {
       action: "correct",
       correction: "The planning call is on Friday.",
     }));
-    expect(screen.getByText(/prior version remains queryable/)).toBeInTheDocument();
+    expect(await screen.findByText(/prior version remains queryable/)).toBeInTheDocument();
   });
 
   it("asks again before forgetting a load-bearing memory", async () => {


### PR DESCRIPTION
Two tests in `hexis-ui/app/forgetting/page.test.tsx` and `hexis-ui/app/learning-review/page.test.tsx` asserted post-decision UI text with a synchronous `screen.getByText()` right after a `waitFor()` that only waits on the *captured request body*, not on the component actually processing the response and re-rendering. That's a real race, not a flake in the harness — it depends on scheduler/CI timing whether the text has committed yet.

Found while investigating two consecutive, unrelated CI failures on PR #119's newly-wired `ui` lane (a different test failed each run). Root-caused it to this pattern (confirmed via 5x repeated local runs before/after). Fix: use `screen.findByText()` (which retries) for the post-decision text, matching the pattern already used elsewhere in both files.

Verified: `npm run test` — 47 files / 123 tests passed, plus 5 repeated targeted runs of both files with no failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for journal compression and learning review flows by waiting for confirmation messages to appear asynchronously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->