### PR TITLE
fix(channels): silence httpx request logging so bot tokens stay out of logs

### DIFF
--- a/services/channel_worker.py
+++ b/services/channel_worker.py
@@ -32,6 +32,11 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
+# python-telegram-bot issues its API calls through httpx, and the bot token
+# is part of the request URL. httpx logs a line per request at INFO, so
+# leaving it enabled writes the token to the logs in plaintext.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
 logger = logging.getLogger("channel_worker")
 
 CHANNEL_CONFIG_POLL_INTERVAL_S = float(

--- a/services/worker_service.py
+++ b/services/worker_service.py
@@ -62,6 +62,11 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
+# python-telegram-bot issues its API calls through httpx, and the bot token
+# is part of the request URL. httpx logs a line per request at INFO, so
+# leaving it enabled writes the token to the logs in plaintext.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
 logger = logging.getLogger("heartbeat_worker")
 
 POLL_INTERVAL = float(os.getenv("WORKER_POLL_INTERVAL", 1.0))


### PR DESCRIPTION
## Problem

`python-telegram-bot` performs its API calls through `httpx`, and the Telegram bot token is part of the request URL. `httpx` logs one line per request at `INFO`, and both worker entrypoints call `logging.basicConfig(level=logging.INFO, ...)` - so the token is written to the logs in plaintext on every long-poll.

Reproduced against httpx 0.28.1:

```
$ python -c "
import logging, httpx
logging.basicConfig(level=logging.INFO, format='%(name)s - %(levelname)s - %(message)s')
httpx.get('https://api.telegram.org/bot123456:AAFAKE-TOKEN-abcdef/getMe')
"
httpx - INFO - HTTP Request: GET https://api.telegram.org/bot123456:AAFAKE-TOKEN-abcdef/getMe "HTTP/1.1 401 Unauthorized"
```

Long-polling means this repeats continuously for the life of the worker, so any log capture, shipped log, or pasted troubleshooting output carries a working bot token.

## Fix

Raise the `httpx` and `httpcore` loggers to `WARNING` in the two entrypoints that own `logging.basicConfig`:

- `services/channel_worker.py` - runs the channel adapters directly.
- `services/worker_service.py` - reaches the same code path through the messaging tools (`core/tools/messaging.py` imports `channels.telegram_adapter` to deliver reach-outs).

Real errors still surface: `WARNING` and above are unaffected, as is every Hexis-owned logger.

## Verification

With the guard in place, the request line is gone and the worker's own logging is untouched:

```
2026-09-01 14:36:36,796 - channel_worker - INFO - worker still logs normally
```

Removing the two `setLevel` lines brings the token line back, so the guard is doing the work rather than passing vacuously.

`python -m py_compile` clean on both files. No behavior change beyond log verbosity; no new dependencies.

Assisted by AI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging privacy by suppressing verbose HTTP request logs that could expose sensitive bot credentials.
  * Sensitive request URLs are no longer recorded in routine informational logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->